### PR TITLE
Pin Substitute button to bottom with entrance animation

### DIFF
--- a/SubTimer/Views/Components/Timer/SubstitutionButtonView.swift
+++ b/SubTimer/Views/Components/Timer/SubstitutionButtonView.swift
@@ -20,13 +20,13 @@ struct SubstitutionButtonView: View {
         Button(action: onSubstitute) {
             HStack {
                 Image(systemName: "arrow.left.arrow.right.circle.fill")
-                    .font(.title2)
+                    .font(.headline)
                 Text("Substitute")
-                    .font(.title2)
+                    .font(.headline)
                     .bold()
             }
             .frame(maxWidth: .infinity)
-            .padding(.vertical, 20)
+            .padding(.vertical, 12)
             .background(canPerformSubstitution ? Color.blue : Color.gray.opacity(0.3))
             .foregroundStyle(.white)
             .cornerRadius(12)

--- a/SubTimer/Views/TimerView.swift
+++ b/SubTimer/Views/TimerView.swift
@@ -179,10 +179,24 @@ struct TimerView: View {
         if !temporarilyOutPlayers.isEmpty {
           temporarilyOutSection
         }
-        substituteButtonSection
       }
       .padding()
     }
+    .safeAreaInset(edge: .bottom) {
+      pinnedSubstituteButton
+    }
+  }
+
+  // MARK: - Pinned Substitute Button
+
+  private var pinnedSubstituteButton: some View {
+    VStack(spacing: 0) {
+      Divider()
+      substituteButtonSection
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+    }
+    .glassEffect(.regular.interactive(), in: .rect)
   }
 
   // MARK: - Timer Controls

--- a/SubTimer/Views/TimerView.swift
+++ b/SubTimer/Views/TimerView.swift
@@ -69,6 +69,7 @@ struct TimerView: View {
   @State var showingPlayerActions: Player?
   @State private var benchOrder: [UUID] = []
   @State private var cachedBenchManager: BenchManager?
+  @State private var showPinnedButton = false
 
   var configuration: AppConfiguration {
     if let config = configurations.first {
@@ -184,6 +185,14 @@ struct TimerView: View {
     }
     .safeAreaInset(edge: .bottom) {
       pinnedSubstituteButton
+        .opacity(showPinnedButton ? 1 : 0)
+        .offset(y: showPinnedButton ? 0 : 40)
+    }
+    .onAppear {
+      guard !showPinnedButton else { return }
+      withAnimation(.easeOut(duration: 0.45).delay(0.15)) {
+        showPinnedButton = true
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Pin the Substitute button to the bottom of the Timer screen using `.safeAreaInset(edge: .bottom)`, outside the `ScrollView`, so it's always visible regardless of scroll position (#11)
- Apply iOS 26 liquid glass effect (`.glassEffect`) with a top divider for visual separation
- Make the button more compact (`.headline` font, 12pt vertical padding) to maximize player list space
- Add a one-time entrance animation (slide-up 40pt + fade-in, 0.45s ease-out) on initial view appearance (#12)

## Changes

**`SubstitutionButtonView.swift`** — Compact styling: reduced font from `.title2` to `.headline`, padding from 20pt to 12pt

**`TimerView.swift`** — Layout restructure + animation:
- Move substitute button out of `ScrollView` into `.safeAreaInset(edge: .bottom)`
- Add `pinnedSubstituteButton` computed property with glass effect + divider
- Add `@State showPinnedButton` flag for one-time entrance animation
- Apply `.opacity()` and `.offset(y:)` modifiers animated via `withAnimation` on first `.onAppear`

## Testing

- Build passes ✅
- All 30 unit tests pass ✅
- Animation plays once on initial load, not on re-renders or tab switches
- No layout shifts — `safeAreaInset` always reserves space
- Button remains tappable after animation completes

Closes #11, closes #12