### PR TITLE
Date-anchored timer model & Live Activity background fix

### DIFF
--- a/ActiveBench/ActiveBenchAttributes.swift
+++ b/ActiveBench/ActiveBenchAttributes.swift
@@ -20,6 +20,9 @@ struct ActiveBenchAttributes: ActivityAttributes {
     var elapsedTime: TimeInterval
     var preferredPlayTimeSeconds: Int
 
+    /// Virtual start date (timerStartDate - accumulatedTime) enabling Text(date, style: .timer) auto-updates in background.
+    var timerRefDate: Date
+
     // Player counts
     var activePlayersCount: Int
     var benchedPlayersCount: Int

--- a/ActiveBench/ActiveBenchLiveActivity.swift
+++ b/ActiveBench/ActiveBenchLiveActivity.swift
@@ -28,17 +28,28 @@ struct ActiveBenchLiveActivity: Widget {
             .font(.caption)
             .foregroundStyle(.secondary)
 
-          Text(formatTime(context.state.elapsedTime))
-            .font(.system(size: 32, weight: .bold, design: .rounded))
-            .monospacedDigit()
-            .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+          if context.state.isRunning {
+            Text(context.state.timerRefDate, style: .timer)
+              .font(.system(size: 32, weight: .bold, design: .rounded))
+              .monospacedDigit()
+              .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+          } else {
+            Text(formatTime(context.state.elapsedTime))
+              .font(.system(size: 32, weight: .bold, design: .rounded))
+              .monospacedDigit()
+              .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+          }
 
           if context.state.preferredPlayTimeSeconds > 0 {
             HStack(spacing: 4) {
               Image(
                 systemName: isOvertime(context.state) ? "exclamationmark.triangle.fill" : "clock"
               )
-              Text(timeRemainingText(context.state))
+              if context.state.isRunning {
+                Text(overtimeDate(context.state), style: .timer)
+              } else {
+                Text(timeRemainingText(context.state))
+              }
             }
             .font(.caption2)
             .foregroundStyle(isOvertime(context.state) ? .red : .secondary)
@@ -79,10 +90,17 @@ struct ActiveBenchLiveActivity: Widget {
             Text("Play Time")
               .font(.caption2)
               .foregroundStyle(.secondary)
-            Text(formatTime(context.state.elapsedTime))
-              .font(.title3)
-              .fontWeight(.semibold)
-              .monospacedDigit()
+            if context.state.isRunning {
+              Text(context.state.timerRefDate, style: .timer)
+                .font(.title3)
+                .fontWeight(.semibold)
+                .monospacedDigit()
+            } else {
+              Text(formatTime(context.state.elapsedTime))
+                .font(.title3)
+                .fontWeight(.semibold)
+                .monospacedDigit()
+            }
           }
         }
 
@@ -113,9 +131,15 @@ struct ActiveBenchLiveActivity: Widget {
             if context.state.preferredPlayTimeSeconds > 0 {
               Spacer()
 
-              Text(timeRemainingText(context.state))
-                .font(.caption)
-                .foregroundStyle(isOvertime(context.state) ? .red : .secondary)
+              if context.state.isRunning {
+                Text(overtimeDate(context.state), style: .timer)
+                  .font(.caption)
+                  .foregroundStyle(isOvertime(context.state) ? .red : .secondary)
+              } else {
+                Text(timeRemainingText(context.state))
+                  .font(.caption)
+                  .foregroundStyle(isOvertime(context.state) ? .red : .secondary)
+              }
             }
           }
         }
@@ -123,9 +147,15 @@ struct ActiveBenchLiveActivity: Widget {
         HStack(spacing: 2) {
           Image(systemName: context.state.isRunning ? "play.fill" : "pause.fill")
             .font(.caption2)
-          Text(formatTimeCompact(context.state.elapsedTime))
-            .font(.caption2)
-            .monospacedDigit()
+          if context.state.isRunning {
+            Text(context.state.timerRefDate, style: .timer)
+              .font(.caption2)
+              .monospacedDigit()
+          } else {
+            Text(formatTimeCompact(context.state.elapsedTime))
+              .font(.caption2)
+              .monospacedDigit()
+          }
         }
       } compactTrailing: {
         HStack(spacing: 4) {
@@ -143,6 +173,10 @@ struct ActiveBenchLiveActivity: Widget {
   }
 
   // MARK: - Helper Functions
+
+  private func overtimeDate(_ state: ActiveBenchAttributes.ContentState) -> Date {
+    state.timerRefDate.addingTimeInterval(TimeInterval(state.preferredPlayTimeSeconds))
+  }
 
   private func formatTime(_ timeInterval: TimeInterval) -> String {
     let totalSeconds = Int(timeInterval)
@@ -194,6 +228,7 @@ extension ActiveBenchAttributes.ContentState {
       isRunning: true,
       elapsedTime: 120,  // 2:00
       preferredPlayTimeSeconds: 180,  // 3:00 preferred
+      timerRefDate: Date().addingTimeInterval(-120),
       activePlayersCount: 5,
       benchedPlayersCount: 3
     )
@@ -204,6 +239,7 @@ extension ActiveBenchAttributes.ContentState {
       isRunning: false,
       elapsedTime: 90,  // 1:30
       preferredPlayTimeSeconds: 180,  // 3:00 preferred
+      timerRefDate: Date(),
       activePlayersCount: 5,
       benchedPlayersCount: 3
     )
@@ -214,6 +250,7 @@ extension ActiveBenchAttributes.ContentState {
       isRunning: true,
       elapsedTime: 240,  // 4:00
       preferredPlayTimeSeconds: 180,  // 3:00 preferred (1 minute over)
+      timerRefDate: Date().addingTimeInterval(-240),
       activePlayersCount: 4,
       benchedPlayersCount: 4
     )

--- a/SubTimer/Models/Player.swift
+++ b/SubTimer/Models/Player.swift
@@ -17,7 +17,7 @@ final class Player {
     var totalPlayTime: TimeInterval
     var status: PlayerStatus
     var sortOrder: Int
-    var activatedAtTime: TimeInterval
+    var activatedAtDate: Date
 
     init(
         id: UUID = UUID(),
@@ -27,7 +27,7 @@ final class Player {
         totalPlayTime: TimeInterval = 0,
         status: PlayerStatus = .benched,
         sortOrder: Int = 0,
-        activatedAtTime: TimeInterval = 0
+        activatedAtDate: Date = Date()
     ) {
         self.id = id
         self.name = name
@@ -36,7 +36,7 @@ final class Player {
         self.totalPlayTime = totalPlayTime
         self.status = status
         self.sortOrder = sortOrder
-        self.activatedAtTime = activatedAtTime
+        self.activatedAtDate = activatedAtDate
     }
 }
 

--- a/SubTimer/Utilities/LiveActivityManager.swift
+++ b/SubTimer/Utilities/LiveActivityManager.swift
@@ -32,6 +32,7 @@ class LiveActivityManager {
     isRunning: Bool,
     elapsedTime: TimeInterval,
     preferredPlayTimeSeconds: Int,
+    timerRefDate: Date,
     activePlayersCount: Int,
     benchedPlayersCount: Int
   ) {
@@ -48,6 +49,7 @@ class LiveActivityManager {
         isRunning: isRunning,
         elapsedTime: elapsedTime,
         preferredPlayTimeSeconds: preferredPlayTimeSeconds,
+        timerRefDate: timerRefDate,
         activePlayersCount: activePlayersCount,
         benchedPlayersCount: benchedPlayersCount
       )
@@ -59,14 +61,18 @@ class LiveActivityManager {
       isRunning: isRunning,
       elapsedTime: elapsedTime,
       preferredPlayTimeSeconds: preferredPlayTimeSeconds,
+      timerRefDate: timerRefDate,
       activePlayersCount: activePlayersCount,
       benchedPlayersCount: benchedPlayersCount
     )
 
     do {
+      let staleDate = computeStaleDate(
+        isRunning: isRunning, timerRefDate: timerRefDate,
+        preferredPlayTimeSeconds: preferredPlayTimeSeconds)
       currentActivity = try Activity.request(
         attributes: attributes,
-        content: ActivityContent(state: contentState, staleDate: nil)
+        content: ActivityContent(state: contentState, staleDate: staleDate)
       )
       print("✅ Live Activity started successfully - Time: \(Int(elapsedTime))s")
     } catch {
@@ -85,6 +91,7 @@ class LiveActivityManager {
     isRunning: Bool,
     elapsedTime: TimeInterval,
     preferredPlayTimeSeconds: Int,
+    timerRefDate: Date,
     activePlayersCount: Int,
     benchedPlayersCount: Int
   ) {
@@ -101,15 +108,19 @@ class LiveActivityManager {
       isRunning: isRunning,
       elapsedTime: elapsedTime,
       preferredPlayTimeSeconds: preferredPlayTimeSeconds,
+      timerRefDate: timerRefDate,
       activePlayersCount: activePlayersCount,
       benchedPlayersCount: benchedPlayersCount
     )
 
     Task {
+      let staleDate = computeStaleDate(
+        isRunning: isRunning, timerRefDate: timerRefDate,
+        preferredPlayTimeSeconds: preferredPlayTimeSeconds)
       await activity.update(
         ActivityContent(
           state: contentState,
-          staleDate: nil
+          staleDate: staleDate
         )
       )
       print("✅ Live Activity updated successfully")
@@ -134,5 +145,13 @@ class LiveActivityManager {
   /// Check if there's an active Live Activity
   var hasActiveActivity: Bool {
     return currentActivity != nil
+  }
+
+  private func computeStaleDate(
+    isRunning: Bool, timerRefDate: Date, preferredPlayTimeSeconds: Int
+  ) -> Date? {
+    guard isRunning, preferredPlayTimeSeconds > 0 else { return nil }
+    let overtime = timerRefDate.addingTimeInterval(TimeInterval(preferredPlayTimeSeconds))
+    return overtime > Date() ? overtime : nil
   }
 }

--- a/SubTimer/ViewModels/TimerViewModel.swift
+++ b/SubTimer/ViewModels/TimerViewModel.swift
@@ -11,42 +11,61 @@ import SwiftData
 @Observable
 class TimerViewModel {
     var isRunning = false
-    var elapsedTime: TimeInterval = 0
+    private(set) var elapsedTime: TimeInterval = 0
     var onTimerTick: (() -> Void)?
 
-    private var timer: Timer?
+    private(set) var timerStartDate: Date?
+    private(set) var accumulatedTime: TimeInterval = 0
+
+    private var displayTimer: Timer?
     private var players: [Player]
 
     init(players: [Player]) {
         self.players = players
     }
 
+    private func computeElapsedTime() -> TimeInterval {
+        guard let start = timerStartDate else { return accumulatedTime }
+        return accumulatedTime + Date().timeIntervalSince(start)
+    }
+
     func startTimer() {
         guard !isRunning else { return }
 
         isRunning = true
-        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            self?.elapsedTime += 1
-            self?.onTimerTick?()
+        timerStartDate = Date()
+        elapsedTime = computeElapsedTime()
+
+        displayTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            self.elapsedTime = self.computeElapsedTime()
+            self.onTimerTick?()
         }
         // ensures timer keeps counting even when scrolling
-        RunLoop.current.add(timer!, forMode: .common)
+        RunLoop.current.add(displayTimer!, forMode: .common)
     }
 
     func pauseTimer() {
+        if let start = timerStartDate {
+            accumulatedTime += Date().timeIntervalSince(start)
+        }
         isRunning = false
-        timer?.invalidate()
-        timer = nil
+        timerStartDate = nil
+        elapsedTime = accumulatedTime
+        displayTimer?.invalidate()
+        displayTimer = nil
     }
 
     func resetTimer() {
         isRunning = false
+        accumulatedTime = 0
+        timerStartDate = nil
         elapsedTime = 0
-        timer?.invalidate()
-        timer = nil
+        displayTimer?.invalidate()
+        displayTimer = nil
     }
 
     deinit {
-        timer?.invalidate()
+        displayTimer?.invalidate()
     }
 }

--- a/SubTimer/Views/SettingsView.swift
+++ b/SubTimer/Views/SettingsView.swift
@@ -267,7 +267,7 @@ extension SettingsView {
 
     func resetAllPlayerTimes() {
         for player in players {
-            player.activatedAtTime = 0
+            player.activatedAtDate = Date()
             player.currentPlayDuration = 0
             player.totalPlayTime = 0
         }

--- a/SubTimer/Views/TimerView.swift
+++ b/SubTimer/Views/TimerView.swift
@@ -380,25 +380,23 @@ extension TimerView {
     guard activePlayers.isEmpty else { return }
     let allFilteredPlayers = activePlayers + benchedPlayers + temporarilyOutPlayers
     let playersToActivate = min(configuration.activePlayersCount, allFilteredPlayers.count)
-    let timerElapsed = timerViewModel?.elapsedTime ?? 0
+    let now = Date()
     for i in 0..<playersToActivate where i < allFilteredPlayers.count {
       allFilteredPlayers[i].status = .active
-      allFilteredPlayers[i].activatedAtTime = timerElapsed
-      allFilteredPlayers[i].currentPlayDuration = 0  // Will be calculated based on activatedAtTime
+      allFilteredPlayers[i].activatedAtDate = now
+      allFilteredPlayers[i].currentPlayDuration = 0
     }
   }
 
   private func updatePlayerTimes() {
-    guard let timerElapsed = timerViewModel?.elapsedTime else { return }
+    let now = Date()
 
-    // Calculate currentPlayDuration based on when each player was activated
-    // This preserves play time for players who aren't being substituted
     for player in activePlayers {
-      player.currentPlayDuration = timerElapsed - player.activatedAtTime
+      player.currentPlayDuration = now.timeIntervalSince(player.activatedAtDate)
     }
 
     if let activeSession = sessions.first(where: { $0.isActive }) {
-      activeSession.duration = Date().timeIntervalSince(activeSession.startDate)
+      activeSession.duration = now.timeIntervalSince(activeSession.startDate)
     }
     checkPreferredTimeAlert()
     updateLiveActivity()
@@ -430,37 +428,22 @@ extension TimerView {
   }
 
   private func performSubstitution(subOut: Player, subIn: Player) {
-    guard let timerElapsed = timerViewModel?.elapsedTime else { return }
-
+    let now = Date()
     let wasRunning = timerViewModel?.isRunning ?? false
 
-    // Pause the timer if it's running
     if wasRunning {
       timerViewModel?.pauseTimer()
     }
 
-    // For all active players EXCEPT the one being subbed out,
-    // preserve their accumulated play time by adjusting their activatedAtTime
-    // to account for the timer reset
-    for player in activePlayers where player.id != subOut.id {
-      let currentAccumulatedTime = timerElapsed - player.activatedAtTime
-      // After timer resets to 0, this negative activatedAtTime will preserve their time
-      player.activatedAtTime = -currentAccumulatedTime
-    }
-
-    // Add the time this player was actually active to their total
-    let timePlayedThisSegment = timerElapsed - subOut.activatedAtTime
+    let timePlayedThisSegment = now.timeIntervalSince(subOut.activatedAtDate)
     subOut.totalPlayTime += timePlayedThisSegment
     subOut.status = .benched
     subOut.currentPlayDuration = 0
 
-    // Set when the new player became active (will be 0 after timer reset)
-    // This ensures they start with 0 current play duration
     subIn.status = .active
-    subIn.activatedAtTime = 0
+    subIn.activatedAtDate = now
     subIn.currentPlayDuration = 0
 
-    // Update bench order: remove the player coming in, then add the player going out
     benchManager.removePlayer(subIn.id)
     benchManager.addPlayer(subOut.id)
     benchOrder = benchManager.playerOrder
@@ -469,10 +452,8 @@ extension TimerView {
       activeSession.substitutionCount += 1
     }
 
-    // Reset the timer to 0
     timerViewModel?.resetTimer()
 
-    // Resume the timer if it was running
     if wasRunning {
       timerViewModel?.startTimer()
     }
@@ -484,10 +465,9 @@ extension TimerView {
   // MARK: - Player Status
 
   func activatePlayer(_ player: Player) {
-    guard let timerElapsed = timerViewModel?.elapsedTime else { return }
     player.status = .active
-    player.activatedAtTime = timerElapsed
-    player.currentPlayDuration = 0  // Will be calculated based on activatedAtTime
+    player.activatedAtDate = Date()
+    player.currentPlayDuration = 0
     benchManager.removePlayer(player.id)
     benchOrder = benchManager.playerOrder
     updateLiveActivity()
@@ -495,8 +475,7 @@ extension TimerView {
 
   func markPlayerTemporarilyOut(_ player: Player) {
     if player.status == .active {
-      guard let timerElapsed = timerViewModel?.elapsedTime else { return }
-      let timePlayedThisSegment = timerElapsed - player.activatedAtTime
+      let timePlayedThisSegment = Date().timeIntervalSince(player.activatedAtDate)
       player.totalPlayTime += timePlayedThisSegment
     }
     player.status = .temporarilyOut

--- a/SubTimer/Views/TimerView.swift
+++ b/SubTimer/Views/TimerView.swift
@@ -544,11 +544,14 @@ extension TimerView {
         sessionName = "Practice Session"
       }
 
+      let refDate = computeTimerRefDate()
+
       LiveActivityManager.shared.startActivity(
         sessionName: sessionName,
         isRunning: timerViewModel?.isRunning ?? false,
         elapsedTime: timerViewModel?.elapsedTime ?? 0,
         preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
+        timerRefDate: refDate,
         activePlayersCount: activePlayers.count,
         benchedPlayersCount: benchedPlayers.count
       )
@@ -557,14 +560,24 @@ extension TimerView {
 
   private func updateLiveActivity() {
     if #available(iOS 16.2, *) {
+      let refDate = computeTimerRefDate()
+
       LiveActivityManager.shared.updateActivity(
         isRunning: timerViewModel?.isRunning ?? false,
         elapsedTime: timerViewModel?.elapsedTime ?? 0,
         preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
+        timerRefDate: refDate,
         activePlayersCount: activePlayers.count,
         benchedPlayersCount: benchedPlayers.count
       )
     }
+  }
+
+  private func computeTimerRefDate() -> Date {
+    guard let vm = timerViewModel, let startDate = vm.timerStartDate else {
+      return Date()
+    }
+    return startDate.addingTimeInterval(-vm.accumulatedTime)
   }
 
   private func endLiveActivity() {

--- a/SubTimerTests/TimerViewModelTests.swift
+++ b/SubTimerTests/TimerViewModelTests.swift
@@ -15,6 +15,9 @@ struct TimerViewModelTests {
         let viewModel = await TimerViewModel(players: players)
 
         #expect(viewModel.isRunning == false)
+        #expect(viewModel.elapsedTime == 0)
+        #expect(viewModel.timerStartDate == nil)
+        #expect(viewModel.accumulatedTime == 0)
         #expect(viewModel.onTimerTick == nil)
     }
 
@@ -25,6 +28,7 @@ struct TimerViewModelTests {
         await viewModel.startTimer()
 
         #expect(viewModel.isRunning == true)
+        #expect(viewModel.timerStartDate != nil)
     }
 
     @Test func startTimerWhenAlreadyRunning() async {
@@ -32,11 +36,12 @@ struct TimerViewModelTests {
         let viewModel = await TimerViewModel(players: players)
 
         await viewModel.startTimer()
+        let firstStartDate = viewModel.timerStartDate
         #expect(viewModel.isRunning == true)
 
-        // Starting again should not change state
         await viewModel.startTimer()
         #expect(viewModel.isRunning == true)
+        #expect(viewModel.timerStartDate == firstStartDate)
     }
 
     @Test func testPauseTimer() async {
@@ -48,6 +53,21 @@ struct TimerViewModelTests {
 
         await viewModel.pauseTimer()
         #expect(viewModel.isRunning == false)
+        #expect(viewModel.timerStartDate == nil)
+    }
+
+    @Test func pauseFoldsTimeIntoAccumulatedTime() async throws {
+        let players = [Player(name: "Player 1")]
+        let viewModel = await TimerViewModel(players: players)
+
+        await viewModel.startTimer()
+        try await Task.sleep(for: .seconds(1.5))
+
+        await viewModel.pauseTimer()
+
+        #expect(viewModel.accumulatedTime >= 1.0)
+        #expect(viewModel.accumulatedTime < 3.0)
+        #expect(viewModel.elapsedTime == viewModel.accumulatedTime)
     }
 
     @Test func pauseTimerWhenNotRunning() async {
@@ -58,6 +78,7 @@ struct TimerViewModelTests {
 
         await viewModel.pauseTimer()
         #expect(viewModel.isRunning == false)
+        #expect(viewModel.accumulatedTime == 0)
     }
 
     @Test func testResetTimer() async {
@@ -69,6 +90,9 @@ struct TimerViewModelTests {
 
         await viewModel.resetTimer()
         #expect(viewModel.isRunning == false)
+        #expect(viewModel.elapsedTime == 0)
+        #expect(viewModel.accumulatedTime == 0)
+        #expect(viewModel.timerStartDate == nil)
     }
 
     @Test func resetTimerWhenNotRunning() async {
@@ -79,21 +103,24 @@ struct TimerViewModelTests {
 
         await viewModel.resetTimer()
         #expect(viewModel.isRunning == false)
+        #expect(viewModel.elapsedTime == 0)
+        #expect(viewModel.accumulatedTime == 0)
     }
 
     @Test func startAfterReset() async {
         let players = [Player(name: "Player 1")]
         let viewModel = await TimerViewModel(players: players)
 
-        // Start, reset, then start again
         await viewModel.startTimer()
         #expect(viewModel.isRunning == true)
 
         await viewModel.resetTimer()
         #expect(viewModel.isRunning == false)
+        #expect(viewModel.elapsedTime == 0)
 
         await viewModel.startTimer()
         #expect(viewModel.isRunning == true)
+        #expect(viewModel.timerStartDate != nil)
     }
 
     @Test func timerTickCallback() async throws {
@@ -107,7 +134,6 @@ struct TimerViewModelTests {
 
         await viewModel.startTimer()
 
-        // Wait for at least 2 seconds to ensure timer ticks
         try await Task.sleep(for: .seconds(2.5))
 
         #expect(tickCount >= 2)
@@ -126,16 +152,13 @@ struct TimerViewModelTests {
 
         await viewModel.startTimer()
 
-        // Wait for some ticks
         try await Task.sleep(for: .seconds(1.5))
 
         await viewModel.pauseTimer()
         let ticksAfterPause = tickCount
 
-        // Wait a bit more
         try await Task.sleep(for: .seconds(1.5))
 
-        // Tick count should not have increased after pause
         #expect(tickCount == ticksAfterPause)
     }
 
@@ -150,16 +173,13 @@ struct TimerViewModelTests {
 
         await viewModel.startTimer()
 
-        // Wait for some ticks
         try await Task.sleep(for: .seconds(1.5))
 
         await viewModel.resetTimer()
         let ticksAfterReset = tickCount
 
-        // Wait a bit more
         try await Task.sleep(for: .seconds(1.5))
 
-        // Tick count should not have increased after reset
         #expect(tickCount == ticksAfterReset)
     }
 
@@ -167,30 +187,22 @@ struct TimerViewModelTests {
         let players = [Player(name: "Player 1")]
         let viewModel = await TimerViewModel(players: players)
 
-        var tickCount = 0
-        viewModel.onTimerTick = {
-            tickCount += 1
-        }
-
-        // First cycle
         await viewModel.startTimer()
         #expect(viewModel.isRunning == true)
         try await Task.sleep(for: .seconds(1.5))
 
         await viewModel.pauseTimer()
         #expect(viewModel.isRunning == false)
-        let firstPauseTicks = tickCount
+        let firstPauseAccumulated = viewModel.accumulatedTime
+        #expect(firstPauseAccumulated >= 1.0)
 
-        // Second cycle
         await viewModel.startTimer()
         #expect(viewModel.isRunning == true)
         try await Task.sleep(for: .seconds(1.5))
 
         await viewModel.pauseTimer()
         #expect(viewModel.isRunning == false)
-
-        // Should have more ticks after second cycle
-        #expect(tickCount > firstPauseTicks)
+        #expect(viewModel.accumulatedTime > firstPauseAccumulated)
     }
 
     @Test func resetClearsTimerCompletely() async throws {
@@ -207,8 +219,9 @@ struct TimerViewModelTests {
 
         await viewModel.resetTimer()
         #expect(viewModel.isRunning == false)
+        #expect(viewModel.elapsedTime == 0)
+        #expect(viewModel.accumulatedTime == 0)
 
-        // Wait to ensure no ticks happen
         let ticksAtReset = tickCount
         try await Task.sleep(for: .seconds(1.5))
 
@@ -230,7 +243,6 @@ struct TimerViewModelTests {
         let players = [Player(name: "Player 1")]
         let viewModel = await TimerViewModel(players: players)
 
-        // Should not crash when starting timer without callback
         await viewModel.startTimer()
         #expect(viewModel.isRunning == true)
 
@@ -238,5 +250,57 @@ struct TimerViewModelTests {
 
         await viewModel.pauseTimer()
         #expect(viewModel.isRunning == false)
+    }
+
+    @Test func elapsedTimeComputedFromDates() async throws {
+        let players = [Player(name: "Player 1")]
+        let viewModel = await TimerViewModel(players: players)
+
+        await viewModel.startTimer()
+        try await Task.sleep(for: .seconds(2.0))
+
+        let elapsed = viewModel.elapsedTime
+        #expect(elapsed >= 1.5)
+        #expect(elapsed < 4.0)
+
+        await viewModel.pauseTimer()
+    }
+
+    @Test func elapsedTimeAccumulatesAcrossPauseResume() async throws {
+        let players = [Player(name: "Player 1")]
+        let viewModel = await TimerViewModel(players: players)
+
+        await viewModel.startTimer()
+        try await Task.sleep(for: .seconds(1.5))
+        await viewModel.pauseTimer()
+        let afterFirstPause = viewModel.elapsedTime
+
+        await viewModel.startTimer()
+        try await Task.sleep(for: .seconds(1.5))
+        await viewModel.pauseTimer()
+        let afterSecondPause = viewModel.elapsedTime
+
+        #expect(afterSecondPause > afterFirstPause)
+        #expect(afterSecondPause >= 2.0)
+    }
+
+    @Test func resetAfterPauseResumeClearsAll() async throws {
+        let players = [Player(name: "Player 1")]
+        let viewModel = await TimerViewModel(players: players)
+
+        await viewModel.startTimer()
+        try await Task.sleep(for: .seconds(1.0))
+        await viewModel.pauseTimer()
+
+        await viewModel.startTimer()
+        try await Task.sleep(for: .seconds(1.0))
+        await viewModel.pauseTimer()
+
+        #expect(viewModel.accumulatedTime >= 1.5)
+
+        await viewModel.resetTimer()
+        #expect(viewModel.elapsedTime == 0)
+        #expect(viewModel.accumulatedTime == 0)
+        #expect(viewModel.timerStartDate == nil)
     }
 }


### PR DESCRIPTION
## Summary

- Replace the incrementing `elapsedTime += 1` counter in `TimerViewModel` with a date-anchored model (`timerStartDate: Date` + `accumulatedTime: TimeInterval`), eliminating timer drift and backgrounding issues
- Convert `Player.activatedAtTime: TimeInterval` to `activatedAtDate: Date`, removing the negative-offset hack in substitution logic (~20 lines of workaround code eliminated)
- Fix Live Activity timer freezing when app is backgrounded by using `Text(date, style: .timer)` — Apple's self-updating timer mechanism that works at the OS level without app process
- Add auto-updating overtime countdown in Live Activity via `Text(overtimeDate, style: .timer)` and set `staleDate` on `ActivityContent` so iOS marks content as outdated after overtime threshold

## Changes

### Commit 1: Date-anchored timer & player model
- **TimerViewModel**: `timerStartDate` + `accumulatedTime` + `computeElapsedTime()`. Display timer kept for UI refresh only.
- **Player**: `activatedAtTime` → `activatedAtDate`
- **TimerView**: All player duration math uses `Date().timeIntervalSince(activatedAtDate)`. Negative-offset hack eliminated entirely.
- **SettingsView**: `resetAllPlayerTimes()` updated for new model
- **Tests**: 3 new date-anchored test cases added, all 44 tests passing

### Commit 2: Live Activity background fix
- **ActiveBenchAttributes**: Added `timerRefDate: Date` to `ContentState` (virtual start date = `timerStartDate - accumulatedTime`)
- **ActiveBenchLiveActivity**: Timer display branches on `isRunning` — running uses `Text(timerRefDate, style: .timer)`, paused uses static `Text(formatTime(elapsedTime))`. Overtime countdown uses `Text(overtimeDate, style: .timer)`.
- **LiveActivityManager**: Passes `timerRefDate` through, computes `staleDate` from overtime threshold
- **TimerView**: Computes `timerRefDate` via `computeTimerRefDate()`

## Known limitations

- Overtime color/icon change (red → warning) only updates when app returns to foreground. The countdown numbers themselves are accurate in real-time.
- Haptic feedback for overtime does not fire when backgrounded — tracked in #23

## Testing

- All 44 tests passing
- Build clean (only pre-existing deprecation warning on `activity.end()`)

Closes #17