### PR TITLE
Add drag-to-reorder support for active players

### DIFF
--- a/SubTimer/Models/ActiveManager.swift
+++ b/SubTimer/Models/ActiveManager.swift
@@ -1,0 +1,82 @@
+//
+//  ActiveManager.swift
+//  SubTimer
+//
+//  Created by SubTimer on 5/5/26.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+final class ActiveManager {
+    var id: UUID
+    var playerOrder: [UUID]
+    var createdDate: Date
+    var updatedDate: Date
+
+    init(
+        id: UUID = UUID(),
+        playerOrder: [UUID] = [],
+        createdDate: Date = Date(),
+        updatedDate: Date = Date()
+    ) {
+        self.id = id
+        self.playerOrder = playerOrder
+        self.createdDate = createdDate
+        self.updatedDate = updatedDate
+    }
+
+    // MARK: - Active Order Management
+
+    /// Adds a player to the end of the active order
+    func addPlayer(_ playerId: UUID) {
+        guard !playerOrder.contains(playerId) else { return }
+        playerOrder.append(playerId)
+        updatedDate = Date()
+    }
+
+    /// Inserts a player at a specific position in the active order
+    func insertPlayer(_ playerId: UUID, at index: Int) {
+        guard !playerOrder.contains(playerId) else { return }
+        let safeIndex = min(max(0, index), playerOrder.count)
+        playerOrder.insert(playerId, at: safeIndex)
+        updatedDate = Date()
+    }
+
+    /// Removes a player from the active order
+    func removePlayer(_ playerId: UUID) {
+        playerOrder.removeAll { $0 == playerId }
+        updatedDate = Date()
+    }
+
+    /// Moves a player to a specific position in the active order
+    func movePlayer(_ playerId: UUID, to index: Int) {
+        guard let currentIndex = playerOrder.firstIndex(of: playerId) else { return }
+        playerOrder.remove(at: currentIndex)
+        let safeIndex = min(max(0, index), playerOrder.count)
+        playerOrder.insert(playerId, at: safeIndex)
+        updatedDate = Date()
+    }
+
+    /// Gets the position of a player in the active order (0-indexed)
+    func position(of playerId: UUID) -> Int? {
+        return playerOrder.firstIndex(of: playerId)
+    }
+
+    /// Returns the player ID at the top of the active order (next to sub out)
+    var nextPlayer: UUID? {
+        return playerOrder.first
+    }
+
+    /// Clears all players from the active order
+    func clear() {
+        playerOrder.removeAll()
+        updatedDate = Date()
+    }
+
+    /// Returns the number of players in the active order
+    var count: Int {
+        return playerOrder.count
+    }
+}

--- a/SubTimer/SubTimerApp.swift
+++ b/SubTimer/SubTimerApp.swift
@@ -15,6 +15,8 @@ struct SubTimerApp: App {
             Player.self,
             AppConfiguration.self,
             Session.self,
+            BenchManager.self,
+            ActiveManager.self,
         ])
 
         // Use in-memory storage for UI testing

--- a/SubTimer/Views/Components/Players/ActivePlayersSectionView.swift
+++ b/SubTimer/Views/Components/Players/ActivePlayersSectionView.swift
@@ -14,12 +14,7 @@ struct ActivePlayersSectionView: View {
     let players: [Player]
     let maxActiveCount: Int
     let onPlayerTap: (Player) -> Void
-
-    // MARK: - Computed Properties
-
-    private var longestPlayingPlayer: Player? {
-        players.max(by: { $0.currentPlayDuration < $1.currentPlayDuration })
-    }
+    let onReorder: (([Player]) -> Void)?
 
     // MARK: - Body
 
@@ -38,17 +33,41 @@ struct ActivePlayersSectionView: View {
             // Content
             if players.isEmpty {
                 emptyStateView
-            } else {
-                LazyVStack(spacing: 8) {
-                    ForEach(players) { player in
+            } else if onReorder != nil {
+                List {
+                    ForEach(Array(players.enumerated()), id: \.element.id) { index, player in
                         ActivePlayerRowView(
                             player: player,
-                            isNextToSubOut: isNextToSubOut(player),
+                            isNextToSubOut: isNextToSubOut(index),
+                            onTap: { onPlayerTap(player) }
+                        )
+                        .listRowInsets(EdgeInsets())
+                        .listRowSeparator(.hidden)
+                        .listRowBackground(
+                            isNextToSubOut(index)
+                                ? RoundedRectangle(cornerRadius: 12).fill(Color.appOrange.opacity(0.1))
+                                : RoundedRectangle(cornerRadius: 12).fill(
+                                    Color(uiColor: .secondarySystemBackground)
+                                )
+                        )
+                    }
+                    .onMove(perform: movePlayer)
+                }
+                .listStyle(.plain)
+                .listRowSpacing(8)
+                .environment(\.editMode, .constant(.active))
+                .frame(height: CGFloat(players.count) * 80)
+            } else {
+                LazyVStack(spacing: 8) {
+                    ForEach(Array(players.enumerated()), id: \.element.id) { index, player in
+                        ActivePlayerRowView(
+                            player: player,
+                            isNextToSubOut: isNextToSubOut(index),
                             onTap: { onPlayerTap(player) }
                         )
                         .padding(.horizontal, 4)
                         .background(
-                            isNextToSubOut(player)
+                            isNextToSubOut(index)
                                 ? RoundedRectangle(cornerRadius: 12).fill(Color.appOrange.opacity(0.1))
                                 : RoundedRectangle(cornerRadius: 12).fill(
                                     Color(uiColor: .secondarySystemBackground)
@@ -73,9 +92,15 @@ struct ActivePlayersSectionView: View {
 
     // MARK: - Helper Methods
 
-    private func isNextToSubOut(_ player: Player) -> Bool {
+    private func isNextToSubOut(_ index: Int) -> Bool {
         guard players.count > 1 else { return false }
-        return longestPlayingPlayer?.id == player.id
+        return index == 0
+    }
+
+    private func movePlayer(from source: IndexSet, to destination: Int) {
+        var reorderedPlayers = players
+        reorderedPlayers.move(fromOffsets: source, toOffset: destination)
+        onReorder?(reorderedPlayers)
     }
 }
 
@@ -90,7 +115,8 @@ struct ActivePlayersSectionView: View {
             Player(name: "Sarah Williams", currentPlayDuration: 150, status: .active),
         ],
         maxActiveCount: 4,
-        onPlayerTap: { player in print("Tapped: \(player.name)") }
+        onPlayerTap: { player in print("Tapped: \(player.name)") },
+        onReorder: { players in print("Reordered: \(players.map { $0.name })") }
     )
     .padding()
 }
@@ -99,7 +125,8 @@ struct ActivePlayersSectionView: View {
     ActivePlayersSectionView(
         players: [],
         maxActiveCount: 4,
-        onPlayerTap: { _ in }
+        onPlayerTap: { _ in },
+        onReorder: nil
     )
     .padding()
 }
@@ -110,7 +137,8 @@ struct ActivePlayersSectionView: View {
             Player(name: "Solo Player", currentPlayDuration: 200, status: .active),
         ],
         maxActiveCount: 4,
-        onPlayerTap: { _ in }
+        onPlayerTap: { _ in },
+        onReorder: nil
     )
     .padding()
 }
@@ -123,7 +151,8 @@ struct ActivePlayersSectionView: View {
             Player(name: "Player 3", currentPlayDuration: 90, status: .active),
         ],
         maxActiveCount: 3,
-        onPlayerTap: { _ in }
+        onPlayerTap: { _ in },
+        onReorder: { _ in print("Reordered") }
     )
     .padding()
 }
@@ -135,7 +164,8 @@ struct ActivePlayersSectionView: View {
             Player(name: "Player 2", currentPlayDuration: 180, status: .active),
         ],
         maxActiveCount: 5,
-        onPlayerTap: { _ in }
+        onPlayerTap: { _ in },
+        onReorder: nil
     )
     .padding()
 }

--- a/SubTimer/Views/TimerView.swift
+++ b/SubTimer/Views/TimerView.swift
@@ -62,13 +62,16 @@ struct TimerView: View {
   @Query private var configurations: [AppConfiguration]
   @Query(sort: \Session.startDate, order: .reverse) var sessions: [Session]
   @Query private var benchManagers: [BenchManager]
+  @Query private var activeManagers: [ActiveManager]
 
   @State var timerViewModel: TimerViewModel?
   @State var showingManualSubstitution = false
   @State var selectedPlayerToSubOut: Player?
   @State var showingPlayerActions: Player?
   @State private var benchOrder: [UUID] = []
+  @State private var activeOrder: [UUID] = []
   @State private var cachedBenchManager: BenchManager?
+  @State private var cachedActiveManager: ActiveManager?
   @State private var showPinnedButton = false
 
   var configuration: AppConfiguration {
@@ -98,9 +101,42 @@ struct TimerView: View {
     }
   }
 
+  var activeManager: ActiveManager {
+    if let cached = cachedActiveManager {
+      return cached
+    }
+
+    if let manager = activeManagers.first {
+      cachedActiveManager = manager
+      return manager
+    } else {
+      let newManager = ActiveManager()
+      modelContext.insert(newManager)
+      try? modelContext.save()
+      cachedActiveManager = newManager
+      return newManager
+    }
+  }
+
   var activePlayers: [Player] {
-    players.filter { $0.status == .active }
-      .sorted(by: { $0.currentPlayDuration > $1.currentPlayDuration })
+    let active = players.filter { $0.status == .active }
+
+    let orderToUse = activeOrder.isEmpty ? (activeManagers.first?.playerOrder ?? []) : activeOrder
+
+    return active.sorted { player1, player2 in
+      let pos1 = orderToUse.firstIndex(of: player1.id)
+      let pos2 = orderToUse.firstIndex(of: player2.id)
+
+      if let p1 = pos1, let p2 = pos2 {
+        return p1 < p2
+      } else if pos1 != nil {
+        return true
+      } else if pos2 != nil {
+        return false
+      } else {
+        return player1.currentPlayDuration > player2.currentPlayDuration
+      }
+    }
   }
 
   var benchedPlayers: [Player] {
@@ -141,11 +177,14 @@ struct TimerView: View {
       }
       .navigationTitle("Super Sub")
       .onAppear {
-        // Initialize cached bench manager first
+        // Initialize cached managers first
         _ = benchManager
+        _ = activeManager
         initializeViewModel(allPlayers: players)
         syncBenchManager()
+        syncActiveManager()
         loadBenchOrder()
+        loadActiveOrder()
       }
       .sheet(isPresented: $showingManualSubstitution) {
         if let playerToSubOut = selectedPlayerToSubOut {
@@ -235,7 +274,8 @@ struct TimerView: View {
     ActivePlayersSectionView(
       players: activePlayers,
       maxActiveCount: configuration.activePlayersCount,
-      onPlayerTap: { player in showingPlayerActions = player }
+      onPlayerTap: { player in showingPlayerActions = player },
+      onReorder: reorderActive
     )
   }
 
@@ -357,6 +397,43 @@ extension TimerView {
     benchOrder = benchManager.playerOrder
   }
 
+  func syncActiveManager() {
+    let manager = activeManager
+    let currentActive = players.filter { $0.status == .active }
+
+    for player in currentActive {
+      if manager.position(of: player.id) == nil {
+        manager.addPlayer(player.id)
+      }
+    }
+
+    let activeIds = Set(currentActive.map { $0.id })
+    manager.playerOrder.removeAll { !activeIds.contains($0) }
+    manager.updatedDate = Date()
+  }
+
+  func loadActiveOrder() {
+    activeOrder = activeManager.playerOrder
+  }
+
+  func reorderActive(_ reorderedPlayers: [Player]) {
+    let newOrder = reorderedPlayers.map { $0.id }
+
+    activeOrder = newOrder
+
+    guard let manager = activeManagers.first else {
+      let newManager = ActiveManager()
+      newManager.playerOrder = newOrder
+      newManager.updatedDate = Date()
+      modelContext.insert(newManager)
+      return
+    }
+
+    manager.playerOrder.removeAll()
+    manager.playerOrder.append(contentsOf: newOrder)
+    manager.updatedDate = Date()
+  }
+
   func toggleTimer() {
     guard let vm = timerViewModel else { return }
     if vm.isRunning {
@@ -385,7 +462,9 @@ extension TimerView {
       allFilteredPlayers[i].status = .active
       allFilteredPlayers[i].activatedAtDate = now
       allFilteredPlayers[i].currentPlayDuration = 0
+      activeManager.addPlayer(allFilteredPlayers[i].id)
     }
+    activeOrder = activeManager.playerOrder
   }
 
   private func updatePlayerTimes() {
@@ -414,8 +493,7 @@ extension TimerView {
 
   func performAutomaticSubstitution() {
     guard
-      let playerToSubOut = activePlayers.max(by: { $0.currentPlayDuration < $1.currentPlayDuration }
-      ),
+      let playerToSubOut = activePlayers.first,
       let playerToSubIn = benchedPlayers.first
     else { return }
     performSubstitution(subOut: playerToSubOut, subIn: playerToSubIn)
@@ -448,6 +526,10 @@ extension TimerView {
     benchManager.addPlayer(subOut.id)
     benchOrder = benchManager.playerOrder
 
+    activeManager.removePlayer(subOut.id)
+    activeManager.addPlayer(subIn.id)
+    activeOrder = activeManager.playerOrder
+
     if let activeSession = sessions.first(where: { $0.isActive }) {
       activeSession.substitutionCount += 1
     }
@@ -470,6 +552,8 @@ extension TimerView {
     player.currentPlayDuration = 0
     benchManager.removePlayer(player.id)
     benchOrder = benchManager.playerOrder
+    activeManager.addPlayer(player.id)
+    activeOrder = activeManager.playerOrder
     updateLiveActivity()
   }
 
@@ -477,6 +561,8 @@ extension TimerView {
     if player.status == .active {
       let timePlayedThisSegment = Date().timeIntervalSince(player.activatedAtDate)
       player.totalPlayTime += timePlayedThisSegment
+      activeManager.removePlayer(player.id)
+      activeOrder = activeManager.playerOrder
     }
     player.status = .temporarilyOut
     updateLiveActivity()

--- a/SubTimerTests/ActiveManagerTests.swift
+++ b/SubTimerTests/ActiveManagerTests.swift
@@ -1,0 +1,173 @@
+//
+//  ActiveManagerTests.swift
+//  SubTimerTests
+//
+//  Created by SubTimer on 5/5/26.
+//
+
+import Foundation
+@testable import SubTimer
+import SwiftData
+import Testing
+
+struct ActiveManagerTests {
+    @Test func initialState() {
+        let manager = ActiveManager()
+        #expect(manager.count == 0)
+        #expect(manager.nextPlayer == nil)
+        #expect(manager.playerOrder.isEmpty)
+    }
+
+    @Test func addPlayer() {
+        let manager = ActiveManager()
+        let id1 = UUID()
+        let id2 = UUID()
+
+        manager.addPlayer(id1)
+        #expect(manager.count == 1)
+        #expect(manager.playerOrder == [id1])
+
+        manager.addPlayer(id2)
+        #expect(manager.count == 2)
+        #expect(manager.playerOrder == [id1, id2])
+    }
+
+    @Test func addPlayerIgnoresDuplicates() {
+        let manager = ActiveManager()
+        let id1 = UUID()
+
+        manager.addPlayer(id1)
+        manager.addPlayer(id1)
+        #expect(manager.count == 1)
+    }
+
+    @Test func removePlayer() {
+        let manager = ActiveManager()
+        let id1 = UUID()
+        let id2 = UUID()
+        let id3 = UUID()
+
+        manager.addPlayer(id1)
+        manager.addPlayer(id2)
+        manager.addPlayer(id3)
+
+        manager.removePlayer(id2)
+        #expect(manager.count == 2)
+        #expect(manager.playerOrder == [id1, id3])
+    }
+
+    @Test func removePlayerNotPresent() {
+        let manager = ActiveManager()
+        let id1 = UUID()
+
+        manager.addPlayer(id1)
+        manager.removePlayer(UUID())
+        #expect(manager.count == 1)
+    }
+
+    @Test func movePlayer() {
+        let manager = ActiveManager()
+        let id1 = UUID()
+        let id2 = UUID()
+        let id3 = UUID()
+
+        manager.addPlayer(id1)
+        manager.addPlayer(id2)
+        manager.addPlayer(id3)
+
+        manager.movePlayer(id3, to: 0)
+        #expect(manager.playerOrder == [id3, id1, id2])
+    }
+
+    @Test func movePlayerToEnd() {
+        let manager = ActiveManager()
+        let id1 = UUID()
+        let id2 = UUID()
+        let id3 = UUID()
+
+        manager.addPlayer(id1)
+        manager.addPlayer(id2)
+        manager.addPlayer(id3)
+
+        manager.movePlayer(id1, to: 2)
+        #expect(manager.playerOrder == [id2, id3, id1])
+    }
+
+    @Test func movePlayerNotPresent() {
+        let manager = ActiveManager()
+        let id1 = UUID()
+
+        manager.addPlayer(id1)
+        manager.movePlayer(UUID(), to: 0)
+        #expect(manager.playerOrder == [id1])
+    }
+
+    @Test func insertPlayer() {
+        let manager = ActiveManager()
+        let id1 = UUID()
+        let id2 = UUID()
+        let id3 = UUID()
+
+        manager.addPlayer(id1)
+        manager.addPlayer(id2)
+
+        manager.insertPlayer(id3, at: 1)
+        #expect(manager.playerOrder == [id1, id3, id2])
+    }
+
+    @Test func insertPlayerIgnoresDuplicates() {
+        let manager = ActiveManager()
+        let id1 = UUID()
+
+        manager.addPlayer(id1)
+        manager.insertPlayer(id1, at: 0)
+        #expect(manager.count == 1)
+    }
+
+    @Test func insertPlayerClampsIndex() {
+        let manager = ActiveManager()
+        let id1 = UUID()
+        let id2 = UUID()
+
+        manager.addPlayer(id1)
+        manager.insertPlayer(id2, at: 100)
+        #expect(manager.playerOrder == [id1, id2])
+    }
+
+    @Test func position() {
+        let manager = ActiveManager()
+        let id1 = UUID()
+        let id2 = UUID()
+
+        manager.addPlayer(id1)
+        manager.addPlayer(id2)
+
+        #expect(manager.position(of: id1) == 0)
+        #expect(manager.position(of: id2) == 1)
+        #expect(manager.position(of: UUID()) == nil)
+    }
+
+    @Test func nextPlayerReturnsFirstInOrder() {
+        let manager = ActiveManager()
+        let id1 = UUID()
+        let id2 = UUID()
+
+        manager.addPlayer(id1)
+        manager.addPlayer(id2)
+        #expect(manager.nextPlayer == id1)
+
+        manager.movePlayer(id2, to: 0)
+        #expect(manager.nextPlayer == id2)
+    }
+
+    @Test func clear() {
+        let manager = ActiveManager()
+        manager.addPlayer(UUID())
+        manager.addPlayer(UUID())
+        manager.addPlayer(UUID())
+
+        manager.clear()
+        #expect(manager.count == 0)
+        #expect(manager.playerOrder.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ActiveManager` SwiftData model to persist user-defined active player ordering (mirrors existing `BenchManager` pattern)
- Updates `ActivePlayersSectionView` with drag-to-reorder via `List` + `.onMove` + drag handles (same UX as bench reorder)
- Changes substitution logic to use position-based ordering: top player = next to sub out, incoming player appended to end

## Details

**New files:**
- `SubTimer/Models/ActiveManager.swift` — SwiftData model tracking `playerOrder: [UUID]`
- `SubTimerTests/ActiveManagerTests.swift` — 14 unit tests covering all operations

**Modified files:**
- `SubTimerApp.swift` — Register `BenchManager` + `ActiveManager` in schema
- `ActivePlayersSectionView.swift` — Add `onReorder` callback, swap `LazyVStack` for `List` with `.onMove` when reorder enabled, highlight index-0 player as next-to-sub-out
- `TimerView.swift` — Add `activeManager` state/query/sync; replace `currentPlayDuration` sort with user-defined order; update substitution + activation + temporarily-out logic to maintain active order

## Testing

- All 14 new `ActiveManagerTests` pass
- All existing tests pass (build + test green)

Closes #27