### PR TITLE
Live Activity Date-Anchored Sync

### DIFF
--- a/ActiveBench/ActiveBenchAttributes.swift
+++ b/ActiveBench/ActiveBenchAttributes.swift
@@ -17,15 +17,19 @@ struct ActiveBenchAttributes: ActivityAttributes {
   public struct ContentState: Codable, Hashable {
     // Timer state properties
     var isRunning: Bool
-    var elapsedTime: TimeInterval
+    var timerStartDate: Date
+    var accumulatedTime: TimeInterval
     var preferredPlayTimeSeconds: Int
-
-    /// Virtual start date (timerStartDate - accumulatedTime) enabling Text(date, style: .timer) auto-updates in background.
-    var timerRefDate: Date
 
     // Player counts
     var activePlayersCount: Int
     var benchedPlayersCount: Int
+
+    /// Virtual reference date (`timerStartDate - accumulatedTime`) that lets
+    /// `Text(date, style: .timer)` show the total elapsed time while running.
+    var timerRefDate: Date {
+      timerStartDate.addingTimeInterval(-accumulatedTime)
+    }
   }
 
   // Fixed non-changing properties about your activity

--- a/ActiveBench/ActiveBenchLiveActivity.swift
+++ b/ActiveBench/ActiveBenchLiveActivity.swift
@@ -34,7 +34,7 @@ struct ActiveBenchLiveActivity: Widget {
               .monospacedDigit()
               .foregroundStyle(isOvertime(context.state) ? .red : .primary)
           } else {
-            Text(formatTime(context.state.elapsedTime))
+            Text(formatTime(context.state.accumulatedTime))
               .font(.system(size: 32, weight: .bold, design: .rounded))
               .monospacedDigit()
               .foregroundStyle(isOvertime(context.state) ? .red : .primary)
@@ -96,7 +96,7 @@ struct ActiveBenchLiveActivity: Widget {
                 .fontWeight(.semibold)
                 .monospacedDigit()
             } else {
-              Text(formatTime(context.state.elapsedTime))
+              Text(formatTime(context.state.accumulatedTime))
                 .font(.title3)
                 .fontWeight(.semibold)
                 .monospacedDigit()
@@ -152,7 +152,7 @@ struct ActiveBenchLiveActivity: Widget {
               .font(.caption2)
               .monospacedDigit()
           } else {
-            Text(formatTimeCompact(context.state.elapsedTime))
+            Text(formatTimeCompact(context.state.accumulatedTime))
               .font(.caption2)
               .monospacedDigit()
           }
@@ -200,11 +200,15 @@ struct ActiveBenchLiveActivity: Widget {
 
   private func isOvertime(_ state: ActiveBenchAttributes.ContentState) -> Bool {
     guard state.preferredPlayTimeSeconds > 0 else { return false }
-    return state.elapsedTime > TimeInterval(state.preferredPlayTimeSeconds)
+    if state.isRunning {
+      let elapsed = Date().timeIntervalSince(state.timerRefDate)
+      return elapsed > TimeInterval(state.preferredPlayTimeSeconds)
+    }
+    return state.accumulatedTime > TimeInterval(state.preferredPlayTimeSeconds)
   }
 
   private func timeRemainingText(_ state: ActiveBenchAttributes.ContentState) -> String {
-    let timeRemaining = TimeInterval(state.preferredPlayTimeSeconds) - state.elapsedTime
+    let timeRemaining = TimeInterval(state.preferredPlayTimeSeconds) - state.accumulatedTime
 
     if timeRemaining < 0 {
       return "Over by \(formatTimeCompact(abs(timeRemaining)))"
@@ -226,9 +230,9 @@ extension ActiveBenchAttributes.ContentState {
   fileprivate static var running: ActiveBenchAttributes.ContentState {
     ActiveBenchAttributes.ContentState(
       isRunning: true,
-      elapsedTime: 120,  // 2:00
-      preferredPlayTimeSeconds: 180,  // 3:00 preferred
-      timerRefDate: Date().addingTimeInterval(-120),
+      timerStartDate: Date().addingTimeInterval(-120),
+      accumulatedTime: 0,
+      preferredPlayTimeSeconds: 180,
       activePlayersCount: 5,
       benchedPlayersCount: 3
     )
@@ -237,9 +241,9 @@ extension ActiveBenchAttributes.ContentState {
   fileprivate static var paused: ActiveBenchAttributes.ContentState {
     ActiveBenchAttributes.ContentState(
       isRunning: false,
-      elapsedTime: 90,  // 1:30
-      preferredPlayTimeSeconds: 180,  // 3:00 preferred
-      timerRefDate: Date(),
+      timerStartDate: Date(),
+      accumulatedTime: 90,
+      preferredPlayTimeSeconds: 180,
       activePlayersCount: 5,
       benchedPlayersCount: 3
     )
@@ -248,9 +252,9 @@ extension ActiveBenchAttributes.ContentState {
   fileprivate static var overtime: ActiveBenchAttributes.ContentState {
     ActiveBenchAttributes.ContentState(
       isRunning: true,
-      elapsedTime: 240,  // 4:00
-      preferredPlayTimeSeconds: 180,  // 3:00 preferred (1 minute over)
-      timerRefDate: Date().addingTimeInterval(-240),
+      timerStartDate: Date().addingTimeInterval(-240),
+      accumulatedTime: 0,
+      preferredPlayTimeSeconds: 180,
       activePlayersCount: 4,
       benchedPlayersCount: 4
     )

--- a/SubTimer/Utilities/LiveActivityManager.swift
+++ b/SubTimer/Utilities/LiveActivityManager.swift
@@ -19,103 +19,76 @@ class LiveActivityManager {
 
   private init() {}
 
-  /// Starts a new Live Activity with the current timer state
-  /// - Parameters:
-  ///   - sessionName: Name of the current session
-  ///   - isRunning: Whether the timer is running
-  ///   - elapsedTime: Current elapsed time
-  ///   - preferredPlayTimeSeconds: Preferred play time in seconds
-  ///   - activePlayersCount: Number of active players
-  ///   - benchedPlayersCount: Number of benched players
   func startActivity(
     sessionName: String,
     isRunning: Bool,
-    elapsedTime: TimeInterval,
+    timerStartDate: Date,
+    accumulatedTime: TimeInterval,
     preferredPlayTimeSeconds: Int,
-    timerRefDate: Date,
     activePlayersCount: Int,
     benchedPlayersCount: Int
   ) {
-    // Check if activities are enabled
     guard ActivityAuthorizationInfo().areActivitiesEnabled else {
       print("⚠️ Live Activities are not enabled")
       return
     }
 
-    // Don't end existing activity - just update it if it exists
     if currentActivity != nil {
-      print("ℹ️ Live Activity already exists, updating instead of recreating")
       updateActivity(
         isRunning: isRunning,
-        elapsedTime: elapsedTime,
+        timerStartDate: timerStartDate,
+        accumulatedTime: accumulatedTime,
         preferredPlayTimeSeconds: preferredPlayTimeSeconds,
-        timerRefDate: timerRefDate,
         activePlayersCount: activePlayersCount,
         benchedPlayersCount: benchedPlayersCount
       )
       return
     }
 
-    let attributes = ActiveBenchAttributes(sessionName: sessionName)
     let contentState = ActiveBenchAttributes.ContentState(
       isRunning: isRunning,
-      elapsedTime: elapsedTime,
+      timerStartDate: timerStartDate,
+      accumulatedTime: accumulatedTime,
       preferredPlayTimeSeconds: preferredPlayTimeSeconds,
-      timerRefDate: timerRefDate,
       activePlayersCount: activePlayersCount,
       benchedPlayersCount: benchedPlayersCount
     )
 
     do {
       let staleDate = computeStaleDate(
-        isRunning: isRunning, timerRefDate: timerRefDate,
+        isRunning: isRunning, timerRefDate: contentState.timerRefDate,
         preferredPlayTimeSeconds: preferredPlayTimeSeconds)
       currentActivity = try Activity.request(
-        attributes: attributes,
+        attributes: ActiveBenchAttributes(sessionName: sessionName),
         content: ActivityContent(state: contentState, staleDate: staleDate)
       )
-      print("✅ Live Activity started successfully - Time: \(Int(elapsedTime))s")
     } catch {
       print("❌ Error starting Live Activity: \(error.localizedDescription)")
     }
   }
 
-  /// Updates the existing Live Activity with new timer state
-  /// - Parameters:
-  ///   - isRunning: Whether the timer is running
-  ///   - elapsedTime: Current elapsed time
-  ///   - preferredPlayTimeSeconds: Preferred play time in seconds
-  ///   - activePlayersCount: Number of active players
-  ///   - benchedPlayersCount: Number of benched players
   func updateActivity(
     isRunning: Bool,
-    elapsedTime: TimeInterval,
+    timerStartDate: Date,
+    accumulatedTime: TimeInterval,
     preferredPlayTimeSeconds: Int,
-    timerRefDate: Date,
     activePlayersCount: Int,
     benchedPlayersCount: Int
   ) {
-    guard let activity = currentActivity else {
-      print("⚠️ No active Live Activity to update")
-      return
-    }
-
-    print(
-      "🔄 Updating Live Activity - Time: \(Int(elapsedTime))s, Running: \(isRunning), Active: \(activePlayersCount), Benched: \(benchedPlayersCount)"
-    )
+    guard let activity = currentActivity else { return }
 
     let contentState = ActiveBenchAttributes.ContentState(
       isRunning: isRunning,
-      elapsedTime: elapsedTime,
+      timerStartDate: timerStartDate,
+      accumulatedTime: accumulatedTime,
       preferredPlayTimeSeconds: preferredPlayTimeSeconds,
-      timerRefDate: timerRefDate,
       activePlayersCount: activePlayersCount,
       benchedPlayersCount: benchedPlayersCount
     )
 
     Task {
       let staleDate = computeStaleDate(
-        isRunning: isRunning, timerRefDate: timerRefDate,
+        isRunning: isRunning, timerRefDate: contentState.timerRefDate,
         preferredPlayTimeSeconds: preferredPlayTimeSeconds)
       await activity.update(
         ActivityContent(
@@ -123,7 +96,6 @@ class LiveActivityManager {
           staleDate: staleDate
         )
       )
-      print("✅ Live Activity updated successfully")
     }
   }
 

--- a/SubTimer/Views/TimerView.swift
+++ b/SubTimer/Views/TimerView.swift
@@ -478,7 +478,6 @@ extension TimerView {
       activeSession.duration = now.timeIntervalSince(activeSession.startDate)
     }
     checkPreferredTimeAlert()
-    updateLiveActivity()
   }
 
   private func checkPreferredTimeAlert() {
@@ -630,14 +629,12 @@ extension TimerView {
         sessionName = "Practice Session"
       }
 
-      let refDate = computeTimerRefDate()
-
       LiveActivityManager.shared.startActivity(
         sessionName: sessionName,
         isRunning: timerViewModel?.isRunning ?? false,
-        elapsedTime: timerViewModel?.elapsedTime ?? 0,
+        timerStartDate: timerViewModel?.timerStartDate ?? Date(),
+        accumulatedTime: timerViewModel?.accumulatedTime ?? 0,
         preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
-        timerRefDate: refDate,
         activePlayersCount: activePlayers.count,
         benchedPlayersCount: benchedPlayers.count
       )
@@ -646,24 +643,15 @@ extension TimerView {
 
   private func updateLiveActivity() {
     if #available(iOS 16.2, *) {
-      let refDate = computeTimerRefDate()
-
       LiveActivityManager.shared.updateActivity(
         isRunning: timerViewModel?.isRunning ?? false,
-        elapsedTime: timerViewModel?.elapsedTime ?? 0,
+        timerStartDate: timerViewModel?.timerStartDate ?? Date(),
+        accumulatedTime: timerViewModel?.accumulatedTime ?? 0,
         preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
-        timerRefDate: refDate,
         activePlayersCount: activePlayers.count,
         benchedPlayersCount: benchedPlayers.count
       )
     }
-  }
-
-  private func computeTimerRefDate() -> Date {
-    guard let vm = timerViewModel, let startDate = vm.timerStartDate else {
-      return Date()
-    }
-    return startDate.addingTimeInterval(-vm.accumulatedTime)
   }
 
   private func endLiveActivity() {

--- a/SubTimer/Views/TimerView.swift
+++ b/SubTimer/Views/TimerView.swift
@@ -73,6 +73,7 @@ struct TimerView: View {
   @State private var cachedBenchManager: BenchManager?
   @State private var cachedActiveManager: ActiveManager?
   @State private var showPinnedButton = false
+  @State private var overtimeUpdateWork: DispatchWorkItem?
 
   var configuration: AppConfiguration {
     if let config = configurations.first {
@@ -438,6 +439,7 @@ extension TimerView {
     guard let vm = timerViewModel else { return }
     if vm.isRunning {
       vm.pauseTimer()
+      cancelOvertimeUpdate()
       updateLiveActivity()
     } else {
       autoActivateInitialPlayersIfNeeded()
@@ -541,9 +543,10 @@ extension TimerView {
 
     provideHapticFeedback()
     updateLiveActivity()
-  }
-
-  // MARK: - Player Status
+    if wasRunning {
+      scheduleOvertimeUpdate()
+    }
+  }  // MARK: - Player Status
 
   func activatePlayer(_ player: Player) {
     player.status = .active
@@ -638,6 +641,7 @@ extension TimerView {
         activePlayersCount: activePlayers.count,
         benchedPlayersCount: benchedPlayers.count
       )
+      scheduleOvertimeUpdate()
     }
   }
 
@@ -656,8 +660,31 @@ extension TimerView {
 
   private func endLiveActivity() {
     if #available(iOS 16.2, *) {
+      cancelOvertimeUpdate()
       LiveActivityManager.shared.endActivity()
     }
+  }
+
+  private func scheduleOvertimeUpdate() {
+    cancelOvertimeUpdate()
+
+    let preferredSeconds = configuration.preferredPlayTimeSeconds
+    guard preferredSeconds > 0 else { return }
+
+    let accumulated = timerViewModel?.accumulatedTime ?? 0
+    let delay = TimeInterval(preferredSeconds) - accumulated
+    guard delay > 0 else { return }
+
+    let work = DispatchWorkItem { [self] in
+      updateLiveActivity()
+    }
+    overtimeUpdateWork = work
+    DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+  }
+
+  private func cancelOvertimeUpdate() {
+    overtimeUpdateWork?.cancel()
+    overtimeUpdateWork = nil
   }
 }
 


### PR DESCRIPTION
## Summary

- Replace snapshot-based `elapsedTime`/`timerRefDate` in `ContentState` with `timerStartDate` and `accumulatedTime` so the system clock drives the Live Activity timer display
- Remove per-tick `updateLiveActivity()` call from `updatePlayerTimes()` — Live Activity updates now fire only on meaningful state changes (start, pause, resume, substitution, player status)
- Update paused state to display frozen timer from `accumulatedTime` with "Paused" indicator

## Changes

### `ActiveBenchAttributes.swift`
- `ContentState` uses `timerStartDate: Date` + `accumulatedTime: TimeInterval` instead of `elapsedTime: TimeInterval`
- `timerRefDate` is now a computed property (`timerStartDate - accumulatedTime`) instead of a stored field

### `ActiveBenchLiveActivity.swift`
- Paused displays use `accumulatedTime` for frozen timer
- `isOvertime()` computes elapsed from `timerRefDate` when running, `accumulatedTime` when paused
- Widget previews updated for new ContentState shape

### `LiveActivityManager.swift`
- API accepts `timerStartDate`/`accumulatedTime` instead of `elapsedTime`/`timerRefDate`
- `staleDate` computed from `contentState.timerRefDate`

### `TimerView.swift`
- **Removed** per-tick `updateLiveActivity()` from `updatePlayerTimes()`
- **Removed** `computeTimerRefDate()` helper — no longer needed
- `startLiveActivity`/`updateLiveActivity` pass `timerStartDate` and `accumulatedTime` directly

## Testing

- Build passes ✅
- All 58 unit tests pass ✅
- Manual testing needed on physical device to verify Live Activity rendering, pause/resume behavior, and timer sync

Closes #18