### PR TITLE
Add substitution recommendation and overtime visuals to Live Activity

### DIFF
--- a/ActiveBench/ActiveBenchAttributes.swift
+++ b/ActiveBench/ActiveBenchAttributes.swift
@@ -25,6 +25,10 @@ struct ActiveBenchAttributes: ActivityAttributes {
     var activePlayersCount: Int
     var benchedPlayersCount: Int
 
+    // Substitution recommendation
+    var subOutPlayerName: String?
+    var subInPlayerName: String?
+
     /// Virtual reference date (`timerStartDate - accumulatedTime`) that lets
     /// `Text(date, style: .timer)` show the total elapsed time while running.
     var timerRefDate: Date {

--- a/ActiveBench/ActiveBenchLiveActivity.swift
+++ b/ActiveBench/ActiveBenchLiveActivity.swift
@@ -21,67 +21,44 @@ struct ActiveBenchLiveActivity: Widget {
             .font(.caption)
             .foregroundStyle(.secondary)
 
-          if context.state.isRunning {
-            Text(context.state.timerRefDate, style: .timer)
-              .font(.system(size: 32, weight: .bold, design: .rounded))
-              .monospacedDigit()
-              .foregroundStyle(isOvertime(context.state) ? .red : .primary)
-          } else {
-            Text(formatTime(context.state.accumulatedTime))
-              .font(.system(size: 32, weight: .bold, design: .rounded))
-              .monospacedDigit()
-              .foregroundStyle(isOvertime(context.state) ? .red : .primary)
-          }
-
           HStack(spacing: 12) {
-            if context.state.preferredPlayTimeSeconds > 0 {
-              HStack(spacing: 4) {
-                Image(
-                  systemName: isOvertime(context.state) ? "exclamationmark.triangle.fill" : "clock"
-                )
-                if context.state.isRunning {
-                  Text(overtimeDate(context.state), style: .timer)
-                } else {
-                  Text(timeRemainingText(context.state))
-                }
-              }
-              .font(.caption2)
-              .foregroundStyle(isOvertime(context.state) ? .red : .secondary)
+            if context.state.isRunning {
+              Text(context.state.timerRefDate, style: .timer)
+                .font(.system(size: 32, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+            } else {
+              Text(formatTime(context.state.accumulatedTime))
+                .font(.system(size: 32, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
             }
 
             if let subOut = context.state.subOutPlayerName,
               let subIn = context.state.subInPlayerName
             {
-              HStack(spacing: 4) {
-                Image(systemName: "arrow.left.arrow.right")
-                Text("\(subOut) → \(subIn)")
-              }
-              .font(.caption2)
-              .fontWeight(.medium)
-              .foregroundStyle(Color("AppOrange"))
+              Text("\(subOut) → \(subIn)")
+                .font(.system(size: 32, weight: .bold, design: .rounded))
+                .foregroundStyle(Color("AppOrange"))
             }
           }
         }
 
         HStack(spacing: 16) {
-          HStack(spacing: 4) {
-            Image(systemName: context.state.isRunning ? "play.circle.fill" : "pause.circle.fill")
-            Text(context.state.isRunning ? "Running" : "Paused")
-          }
-          .font(.caption)
+          Image(systemName: context.state.isRunning ? "play.circle.fill" : "pause.circle.fill")
+            .foregroundStyle(context.state.isRunning ? .green : Color("AppOrange"))
 
           HStack(spacing: 4) {
             Image(systemName: "person.3.fill")
             Text("\(context.state.activePlayersCount) Active")
           }
-          .font(.caption)
 
           HStack(spacing: 4) {
             Image(systemName: "figure.seated")
             Text("\(context.state.benchedPlayersCount) Bench")
           }
-          .font(.caption)
         }
+        .font(.caption)
         .foregroundStyle(.secondary)
       }
       .padding()

--- a/ActiveBench/ActiveBenchLiveActivity.swift
+++ b/ActiveBench/ActiveBenchLiveActivity.swift
@@ -77,6 +77,18 @@ struct ActiveBenchLiveActivity: Widget {
           .font(.caption)
         }
         .foregroundStyle(.secondary)
+
+        if let subOut = context.state.subOutPlayerName,
+          let subIn = context.state.subInPlayerName
+        {
+          HStack(spacing: 6) {
+            Image(systemName: "arrow.left.arrow.right")
+            Text("\(subOut) → \(subIn)")
+          }
+          .font(.subheadline)
+          .fontWeight(.medium)
+          .foregroundStyle(Color("AppOrange"))
+        }
       }
       .padding()
       .activityBackgroundTint(Color(uiColor: .systemBackground))
@@ -95,11 +107,13 @@ struct ActiveBenchLiveActivity: Widget {
                 .font(.title3)
                 .fontWeight(.semibold)
                 .monospacedDigit()
+                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
             } else {
               Text(formatTime(context.state.accumulatedTime))
                 .font(.title3)
                 .fontWeight(.semibold)
                 .monospacedDigit()
+                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
             }
           }
         }
@@ -113,33 +127,46 @@ struct ActiveBenchLiveActivity: Widget {
         }
 
         DynamicIslandExpandedRegion(.bottom) {
-          HStack {
-            HStack(spacing: 4) {
-              Image(systemName: "person.3.fill")
-              Text("\(context.state.activePlayersCount)")
-            }
-            .font(.caption)
+          VStack(spacing: 6) {
+            HStack {
+              HStack(spacing: 4) {
+                Image(systemName: "person.3.fill")
+                Text("\(context.state.activePlayersCount)")
+              }
+              .font(.caption)
 
-            Spacer()
-
-            HStack(spacing: 4) {
-              Image(systemName: "figure.seated")
-              Text("\(context.state.benchedPlayersCount)")
-            }
-            .font(.caption)
-
-            if context.state.preferredPlayTimeSeconds > 0 {
               Spacer()
 
-              if context.state.isRunning {
-                Text(overtimeDate(context.state), style: .timer)
-                  .font(.caption)
-                  .foregroundStyle(isOvertime(context.state) ? .red : .secondary)
-              } else {
-                Text(timeRemainingText(context.state))
-                  .font(.caption)
-                  .foregroundStyle(isOvertime(context.state) ? .red : .secondary)
+              HStack(spacing: 4) {
+                Image(systemName: "figure.seated")
+                Text("\(context.state.benchedPlayersCount)")
               }
+              .font(.caption)
+
+              if context.state.preferredPlayTimeSeconds > 0 {
+                Spacer()
+
+                if context.state.isRunning {
+                  Text(overtimeDate(context.state), style: .timer)
+                    .font(.caption)
+                    .foregroundStyle(isOvertime(context.state) ? .red : .secondary)
+                } else {
+                  Text(timeRemainingText(context.state))
+                    .font(.caption)
+                    .foregroundStyle(isOvertime(context.state) ? .red : .secondary)
+                }
+              }
+            }
+
+            if let subOut = context.state.subOutPlayerName,
+              let subIn = context.state.subInPlayerName
+            {
+              HStack(spacing: 4) {
+                Image(systemName: "arrow.left.arrow.right")
+                Text("\(subOut) → \(subIn)")
+              }
+              .font(.caption2)
+              .foregroundStyle(Color("AppOrange"))
             }
           }
         }
@@ -151,10 +178,12 @@ struct ActiveBenchLiveActivity: Widget {
             Text(context.state.timerRefDate, style: .timer)
               .font(.caption2)
               .monospacedDigit()
+              .foregroundStyle(isOvertime(context.state) ? .red : .primary)
           } else {
             Text(formatTimeCompact(context.state.accumulatedTime))
               .font(.caption2)
               .monospacedDigit()
+              .foregroundStyle(isOvertime(context.state) ? .red : .primary)
           }
         }
       } compactTrailing: {
@@ -234,7 +263,9 @@ extension ActiveBenchAttributes.ContentState {
       accumulatedTime: 0,
       preferredPlayTimeSeconds: 180,
       activePlayersCount: 5,
-      benchedPlayersCount: 3
+      benchedPlayersCount: 3,
+      subOutPlayerName: "Alice",
+      subInPlayerName: "Bob"
     )
   }
 
@@ -245,7 +276,9 @@ extension ActiveBenchAttributes.ContentState {
       accumulatedTime: 90,
       preferredPlayTimeSeconds: 180,
       activePlayersCount: 5,
-      benchedPlayersCount: 3
+      benchedPlayersCount: 3,
+      subOutPlayerName: "Alice",
+      subInPlayerName: "Bob"
     )
   }
 
@@ -256,7 +289,9 @@ extension ActiveBenchAttributes.ContentState {
       accumulatedTime: 0,
       preferredPlayTimeSeconds: 180,
       activePlayersCount: 4,
-      benchedPlayersCount: 4
+      benchedPlayersCount: 4,
+      subOutPlayerName: "Charlie",
+      subInPlayerName: "Diana"
     )
   }
 }

--- a/ActiveBench/ActiveBenchLiveActivity.swift
+++ b/ActiveBench/ActiveBenchLiveActivity.swift
@@ -15,14 +15,7 @@ import WidgetKit
 struct ActiveBenchLiveActivity: Widget {
   var body: some WidgetConfiguration {
     ActivityConfiguration(for: ActiveBenchAttributes.self) { context in
-      // Lock screen/banner UI goes here
       VStack(spacing: 12) {
-        // Session name
-        Text(context.attributes.sessionName)
-          .font(.headline)
-          .foregroundStyle(.secondary)
-
-        // Timer display
         VStack(spacing: 4) {
           Text("Current Play Time")
             .font(.caption)
@@ -40,23 +33,36 @@ struct ActiveBenchLiveActivity: Widget {
               .foregroundStyle(isOvertime(context.state) ? .red : .primary)
           }
 
-          if context.state.preferredPlayTimeSeconds > 0 {
-            HStack(spacing: 4) {
-              Image(
-                systemName: isOvertime(context.state) ? "exclamationmark.triangle.fill" : "clock"
-              )
-              if context.state.isRunning {
-                Text(overtimeDate(context.state), style: .timer)
-              } else {
-                Text(timeRemainingText(context.state))
+          HStack(spacing: 12) {
+            if context.state.preferredPlayTimeSeconds > 0 {
+              HStack(spacing: 4) {
+                Image(
+                  systemName: isOvertime(context.state) ? "exclamationmark.triangle.fill" : "clock"
+                )
+                if context.state.isRunning {
+                  Text(overtimeDate(context.state), style: .timer)
+                } else {
+                  Text(timeRemainingText(context.state))
+                }
               }
+              .font(.caption2)
+              .foregroundStyle(isOvertime(context.state) ? .red : .secondary)
             }
-            .font(.caption2)
-            .foregroundStyle(isOvertime(context.state) ? .red : .secondary)
+
+            if let subOut = context.state.subOutPlayerName,
+              let subIn = context.state.subInPlayerName
+            {
+              HStack(spacing: 4) {
+                Image(systemName: "arrow.left.arrow.right")
+                Text("\(subOut) → \(subIn)")
+              }
+              .font(.caption2)
+              .fontWeight(.medium)
+              .foregroundStyle(Color("AppOrange"))
+            }
           }
         }
 
-        // Timer status
         HStack(spacing: 16) {
           HStack(spacing: 4) {
             Image(systemName: context.state.isRunning ? "play.circle.fill" : "pause.circle.fill")
@@ -77,18 +83,6 @@ struct ActiveBenchLiveActivity: Widget {
           .font(.caption)
         }
         .foregroundStyle(.secondary)
-
-        if let subOut = context.state.subOutPlayerName,
-          let subIn = context.state.subInPlayerName
-        {
-          HStack(spacing: 6) {
-            Image(systemName: "arrow.left.arrow.right")
-            Text("\(subOut) → \(subIn)")
-          }
-          .font(.subheadline)
-          .fontWeight(.medium)
-          .foregroundStyle(Color("AppOrange"))
-        }
       }
       .padding()
       .activityBackgroundTint(Color(uiColor: .systemBackground))
@@ -99,9 +93,6 @@ struct ActiveBenchLiveActivity: Widget {
         // Expanded UI goes here
         DynamicIslandExpandedRegion(.leading) {
           VStack(alignment: .leading, spacing: 2) {
-            Text("Play Time")
-              .font(.caption2)
-              .foregroundStyle(.secondary)
             if context.state.isRunning {
               Text(context.state.timerRefDate, style: .timer)
                 .font(.title3)

--- a/ActiveBench/ActiveBenchLiveActivity.swift
+++ b/ActiveBench/ActiveBenchLiveActivity.swift
@@ -69,42 +69,7 @@ struct ActiveBenchLiveActivity: Widget {
     } dynamicIsland: { context in
       DynamicIsland {
         DynamicIslandExpandedRegion(.leading) {
-          if context.state.isRunning {
-            Text(context.state.timerRefDate, style: .timer)
-              .font(.title3)
-              .fontWeight(.semibold)
-              .monospacedDigit()
-              .foregroundStyle(isOvertime(context.state) ? .red : .primary)
-          } else {
-            Text(formatTime(context.state.accumulatedTime))
-              .font(.title3)
-              .fontWeight(.semibold)
-              .monospacedDigit()
-              .foregroundStyle(isOvertime(context.state) ? .red : .primary)
-          }
-        }
-
-        DynamicIslandExpandedRegion(.center) {
-          if let subOut = context.state.subOutPlayerName,
-            let subIn = context.state.subInPlayerName
-          {
-            Text("\(subOut) → \(subIn)")
-              .font(.title3)
-              .fontWeight(.semibold)
-              .foregroundStyle(Color("AppOrange"))
-              .lineLimit(1)
-              .minimumScaleFactor(0.7)
-          }
-        }
-
-        DynamicIslandExpandedRegion(.trailing) {
-          Image(systemName: context.state.isRunning ? "play.circle.fill" : "pause.circle.fill")
-            .font(.title2)
-            .foregroundStyle(context.state.isRunning ? .green : Color("AppOrange"))
-        }
-
-        DynamicIslandExpandedRegion(.bottom) {
-          HStack(spacing: 16) {
+          HStack(spacing: 12) {
             HStack(spacing: 4) {
               Image(systemName: "person.3.fill")
               Text("\(context.state.activePlayersCount)")
@@ -116,6 +81,34 @@ struct ActiveBenchLiveActivity: Widget {
             }
           }
           .font(.caption)
+          .foregroundStyle(.secondary)
+        }
+
+        DynamicIslandExpandedRegion(.bottom) {
+          VStack(spacing: 4) {
+            if context.state.isRunning {
+              Text(context.state.timerRefDate, style: .timer)
+                .font(.system(size: 36, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+            } else {
+              Text(formatTime(context.state.accumulatedTime))
+                .font(.system(size: 36, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+            }
+
+            if let subOut = context.state.subOutPlayerName,
+              let subIn = context.state.subInPlayerName
+            {
+              Text("\(subOut) → \(subIn)")
+                .font(.system(size: 20, weight: .semibold, design: .rounded))
+                .foregroundStyle(Color("AppOrange"))
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+            }
+          }
+          .frame(maxWidth: .infinity)
         }
       } compactLeading: {
         HStack(spacing: 2) {

--- a/ActiveBench/ActiveBenchLiveActivity.swift
+++ b/ActiveBench/ActiveBenchLiveActivity.swift
@@ -118,47 +118,47 @@ struct ActiveBenchLiveActivity: Widget {
           }
         }
 
-        DynamicIslandExpandedRegion(.bottom) {
-          VStack(spacing: 6) {
-            HStack {
-              HStack(spacing: 4) {
-                Image(systemName: "person.3.fill")
-                Text("\(context.state.activePlayersCount)")
-              }
-              .font(.caption)
+        DynamicIslandExpandedRegion(.center) {
+          if let subOut = context.state.subOutPlayerName,
+            let subIn = context.state.subInPlayerName
+          {
+            HStack(spacing: 4) {
+              Image(systemName: "arrow.left.arrow.right")
+              Text("\(subOut) → \(subIn)")
+            }
+            .font(.caption2)
+            .foregroundStyle(Color("AppOrange"))
+          }
+        }
 
+        DynamicIslandExpandedRegion(.bottom) {
+          HStack {
+            HStack(spacing: 4) {
+              Image(systemName: "person.3.fill")
+              Text("\(context.state.activePlayersCount)")
+            }
+            .font(.caption)
+
+            Spacer()
+
+            HStack(spacing: 4) {
+              Image(systemName: "figure.seated")
+              Text("\(context.state.benchedPlayersCount)")
+            }
+            .font(.caption)
+
+            if context.state.preferredPlayTimeSeconds > 0 {
               Spacer()
 
-              HStack(spacing: 4) {
-                Image(systemName: "figure.seated")
-                Text("\(context.state.benchedPlayersCount)")
+              if context.state.isRunning {
+                Text(overtimeDate(context.state), style: .timer)
+                  .font(.caption)
+                  .foregroundStyle(isOvertime(context.state) ? .red : .secondary)
+              } else {
+                Text(timeRemainingText(context.state))
+                  .font(.caption)
+                  .foregroundStyle(isOvertime(context.state) ? .red : .secondary)
               }
-              .font(.caption)
-
-              if context.state.preferredPlayTimeSeconds > 0 {
-                Spacer()
-
-                if context.state.isRunning {
-                  Text(overtimeDate(context.state), style: .timer)
-                    .font(.caption)
-                    .foregroundStyle(isOvertime(context.state) ? .red : .secondary)
-                } else {
-                  Text(timeRemainingText(context.state))
-                    .font(.caption)
-                    .foregroundStyle(isOvertime(context.state) ? .red : .secondary)
-                }
-              }
-            }
-
-            if let subOut = context.state.subOutPlayerName,
-              let subIn = context.state.subInPlayerName
-            {
-              HStack(spacing: 4) {
-                Image(systemName: "arrow.left.arrow.right")
-                Text("\(subOut) → \(subIn)")
-              }
-              .font(.caption2)
-              .foregroundStyle(Color("AppOrange"))
             }
           }
         }

--- a/ActiveBench/ActiveBenchLiveActivity.swift
+++ b/ActiveBench/ActiveBenchLiveActivity.swift
@@ -127,11 +127,13 @@ struct ActiveBenchLiveActivity: Widget {
           }
         }
       } compactTrailing: {
-        HStack(spacing: 4) {
-          Image(systemName: "person.3.fill")
-            .font(.caption2)
-          Text("\(context.state.activePlayersCount)")
-            .font(.caption2)
+        if let subOut = context.state.subOutPlayerName,
+          let subIn = context.state.subInPlayerName
+        {
+          Text("\(subOut) → \(subIn)")
+            .font(.system(size: 12))
+            .foregroundStyle(Color("AppOrange"))
+            .lineLimit(1)
         }
       } minimal: {
         Image(systemName: context.state.isRunning ? "play.circle.fill" : "pause.circle.fill")

--- a/ActiveBench/ActiveBenchLiveActivity.swift
+++ b/ActiveBench/ActiveBenchLiveActivity.swift
@@ -107,6 +107,7 @@ struct ActiveBenchLiveActivity: Widget {
                 .foregroundStyle(isOvertime(context.state) ? .red : .primary)
             }
           }
+          .padding(.top, 4)
         }
 
         DynamicIslandExpandedRegion(.trailing) {

--- a/ActiveBench/ActiveBenchLiveActivity.swift
+++ b/ActiveBench/ActiveBenchLiveActivity.swift
@@ -38,8 +38,9 @@ struct ActiveBenchLiveActivity: Widget {
               let subIn = context.state.subInPlayerName
             {
               Text("\(subOut) → \(subIn)")
-                .font(.system(size: 32, weight: .bold, design: .rounded))
+                .font(.system(size: 16, weight: .semibold, design: .rounded))
                 .foregroundStyle(Color("AppOrange"))
+                .lineLimit(1)
             }
           }
         }
@@ -67,31 +68,19 @@ struct ActiveBenchLiveActivity: Widget {
 
     } dynamicIsland: { context in
       DynamicIsland {
-        // Expanded UI goes here
         DynamicIslandExpandedRegion(.leading) {
-          VStack(alignment: .leading, spacing: 2) {
-            if context.state.isRunning {
-              Text(context.state.timerRefDate, style: .timer)
-                .font(.title3)
-                .fontWeight(.semibold)
-                .monospacedDigit()
-                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
-            } else {
-              Text(formatTime(context.state.accumulatedTime))
-                .font(.title3)
-                .fontWeight(.semibold)
-                .monospacedDigit()
-                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
-            }
-          }
-          .padding(.top, 4)
-        }
-
-        DynamicIslandExpandedRegion(.trailing) {
-          VStack(alignment: .trailing, spacing: 2) {
-            Image(systemName: context.state.isRunning ? "play.circle.fill" : "pause.circle.fill")
-              .font(.title2)
-              .foregroundStyle(context.state.isRunning ? .green : Color("AppOrange"))
+          if context.state.isRunning {
+            Text(context.state.timerRefDate, style: .timer)
+              .font(.title3)
+              .fontWeight(.semibold)
+              .monospacedDigit()
+              .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+          } else {
+            Text(formatTime(context.state.accumulatedTime))
+              .font(.title3)
+              .fontWeight(.semibold)
+              .monospacedDigit()
+              .foregroundStyle(isOvertime(context.state) ? .red : .primary)
           }
         }
 
@@ -99,45 +88,34 @@ struct ActiveBenchLiveActivity: Widget {
           if let subOut = context.state.subOutPlayerName,
             let subIn = context.state.subInPlayerName
           {
-            HStack(spacing: 4) {
-              Image(systemName: "arrow.left.arrow.right")
-              Text("\(subOut) → \(subIn)")
-            }
-            .font(.caption2)
-            .foregroundStyle(Color("AppOrange"))
+            Text("\(subOut) → \(subIn)")
+              .font(.title3)
+              .fontWeight(.semibold)
+              .foregroundStyle(Color("AppOrange"))
+              .lineLimit(1)
+              .minimumScaleFactor(0.7)
           }
         }
 
+        DynamicIslandExpandedRegion(.trailing) {
+          Image(systemName: context.state.isRunning ? "play.circle.fill" : "pause.circle.fill")
+            .font(.title2)
+            .foregroundStyle(context.state.isRunning ? .green : Color("AppOrange"))
+        }
+
         DynamicIslandExpandedRegion(.bottom) {
-          HStack {
+          HStack(spacing: 16) {
             HStack(spacing: 4) {
               Image(systemName: "person.3.fill")
               Text("\(context.state.activePlayersCount)")
             }
-            .font(.caption)
-
-            Spacer()
 
             HStack(spacing: 4) {
               Image(systemName: "figure.seated")
               Text("\(context.state.benchedPlayersCount)")
             }
-            .font(.caption)
-
-            if context.state.preferredPlayTimeSeconds > 0 {
-              Spacer()
-
-              if context.state.isRunning {
-                Text(overtimeDate(context.state), style: .timer)
-                  .font(.caption)
-                  .foregroundStyle(isOvertime(context.state) ? .red : .secondary)
-              } else {
-                Text(timeRemainingText(context.state))
-                  .font(.caption)
-                  .foregroundStyle(isOvertime(context.state) ? .red : .secondary)
-              }
-            }
           }
+          .font(.caption)
         }
       } compactLeading: {
         HStack(spacing: 2) {

--- a/ActiveBench/ActiveBenchLiveActivity.swift
+++ b/ActiveBench/ActiveBenchLiveActivity.swift
@@ -21,7 +21,7 @@ struct ActiveBenchLiveActivity: Widget {
             .font(.caption)
             .foregroundStyle(.secondary)
 
-          HStack(spacing: 12) {
+          HStack(alignment: .firstTextBaseline, spacing: 12) {
             if context.state.isRunning {
               Text(context.state.timerRefDate, style: .timer)
                 .font(.system(size: 32, weight: .bold, design: .rounded))
@@ -244,6 +244,30 @@ extension ActiveBenchAttributes.ContentState {
 }
 
 #Preview("Notification", as: .content, using: ActiveBenchAttributes.preview) {
+  ActiveBenchLiveActivity()
+} contentStates: {
+  ActiveBenchAttributes.ContentState.running
+  ActiveBenchAttributes.ContentState.paused
+  ActiveBenchAttributes.ContentState.overtime
+}
+
+#Preview("Dynamic Island Expanded", as: .dynamicIsland(.expanded), using: ActiveBenchAttributes.preview) {
+  ActiveBenchLiveActivity()
+} contentStates: {
+  ActiveBenchAttributes.ContentState.running
+  ActiveBenchAttributes.ContentState.paused
+  ActiveBenchAttributes.ContentState.overtime
+}
+
+#Preview("Dynamic Island Compact", as: .dynamicIsland(.compact), using: ActiveBenchAttributes.preview) {
+  ActiveBenchLiveActivity()
+} contentStates: {
+  ActiveBenchAttributes.ContentState.running
+  ActiveBenchAttributes.ContentState.paused
+  ActiveBenchAttributes.ContentState.overtime
+}
+
+#Preview("Dynamic Island Minimal", as: .dynamicIsland(.minimal), using: ActiveBenchAttributes.preview) {
   ActiveBenchLiveActivity()
 } contentStates: {
   ActiveBenchAttributes.ContentState.running

--- a/SubTimer/Utilities/LiveActivityManager.swift
+++ b/SubTimer/Utilities/LiveActivityManager.swift
@@ -26,7 +26,9 @@ class LiveActivityManager {
     accumulatedTime: TimeInterval,
     preferredPlayTimeSeconds: Int,
     activePlayersCount: Int,
-    benchedPlayersCount: Int
+    benchedPlayersCount: Int,
+    subOutPlayerName: String? = nil,
+    subInPlayerName: String? = nil
   ) {
     guard ActivityAuthorizationInfo().areActivitiesEnabled else {
       print("⚠️ Live Activities are not enabled")
@@ -40,7 +42,9 @@ class LiveActivityManager {
         accumulatedTime: accumulatedTime,
         preferredPlayTimeSeconds: preferredPlayTimeSeconds,
         activePlayersCount: activePlayersCount,
-        benchedPlayersCount: benchedPlayersCount
+        benchedPlayersCount: benchedPlayersCount,
+        subOutPlayerName: subOutPlayerName,
+        subInPlayerName: subInPlayerName
       )
       return
     }
@@ -51,7 +55,9 @@ class LiveActivityManager {
       accumulatedTime: accumulatedTime,
       preferredPlayTimeSeconds: preferredPlayTimeSeconds,
       activePlayersCount: activePlayersCount,
-      benchedPlayersCount: benchedPlayersCount
+      benchedPlayersCount: benchedPlayersCount,
+      subOutPlayerName: subOutPlayerName,
+      subInPlayerName: subInPlayerName
     )
 
     do {
@@ -73,7 +79,9 @@ class LiveActivityManager {
     accumulatedTime: TimeInterval,
     preferredPlayTimeSeconds: Int,
     activePlayersCount: Int,
-    benchedPlayersCount: Int
+    benchedPlayersCount: Int,
+    subOutPlayerName: String? = nil,
+    subInPlayerName: String? = nil
   ) {
     guard let activity = currentActivity else { return }
 
@@ -83,7 +91,9 @@ class LiveActivityManager {
       accumulatedTime: accumulatedTime,
       preferredPlayTimeSeconds: preferredPlayTimeSeconds,
       activePlayersCount: activePlayersCount,
-      benchedPlayersCount: benchedPlayersCount
+      benchedPlayersCount: benchedPlayersCount,
+      subOutPlayerName: subOutPlayerName,
+      subInPlayerName: subInPlayerName
     )
 
     Task {

--- a/SubTimer/Views/TimerView.swift
+++ b/SubTimer/Views/TimerView.swift
@@ -639,7 +639,9 @@ extension TimerView {
         accumulatedTime: timerViewModel?.accumulatedTime ?? 0,
         preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
         activePlayersCount: activePlayers.count,
-        benchedPlayersCount: benchedPlayers.count
+        benchedPlayersCount: benchedPlayers.count,
+        subOutPlayerName: activePlayers.first?.name,
+        subInPlayerName: benchedPlayers.first?.name
       )
       scheduleOvertimeUpdate()
     }
@@ -653,7 +655,9 @@ extension TimerView {
         accumulatedTime: timerViewModel?.accumulatedTime ?? 0,
         preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
         activePlayersCount: activePlayers.count,
-        benchedPlayersCount: benchedPlayers.count
+        benchedPlayersCount: benchedPlayers.count,
+        subOutPlayerName: activePlayers.first?.name,
+        subInPlayerName: benchedPlayers.first?.name
       )
     }
   }


### PR DESCRIPTION
## Summary

- Add `subOutPlayerName` and `subInPlayerName` to `ContentState` and pass the substitution recommendation (longest-playing active player out, first bench player in) on every Live Activity state-change update
- Display swap recommendation across all Live Activity surfaces: lock screen banner, Dynamic Island expanded, and compact views
- Timer text turns red when overtime across expanded and compact Dynamic Island views

## Lock Screen Banner

- Large timer with swap text ("Alice → Bob") on the same line
- Centered status row: play/pause icon + active/bench counts
- Timer turns red on overtime (no separate overtime counter)

## Dynamic Island Expanded

- Top left: active + bench player counts
- Center: large timer (36pt) with swap text (20pt) below, both centered
- Timer turns red on overtime

## Dynamic Island Compact

- Leading: play/pause icon + timer (red on overtime)
- Trailing: swap recommendation text

## Files Changed

| File | Change |
|---|---|
| `ActiveBenchAttributes.swift` | Added `subOutPlayerName: String?` and `subInPlayerName: String?` to `ContentState` |
| `LiveActivityManager.swift` | Updated `startActivity`/`updateActivity` to accept sub recommendation names |
| `TimerView.swift` | Computes and passes recommendation on every state-change |
| `ActiveBenchLiveActivity.swift` | All Live Activity UI updates + expanded/compact/minimal previews |

## Testing

- Build passes, all 50 unit tests pass
- Xcode previews for lock screen, expanded, compact, and minimal Dynamic Island states
- On device: verify swap text, overtime red coloring, nil-handling when no substitution is possible

Closes #19