### PR TITLE
Refactor player row interactions: eliminate nested buttons, add explicit action targets

### DIFF
--- a/SubTimer/Utilities/LiveActivityManager.swift
+++ b/SubTimer/Utilities/LiveActivityManager.swift
@@ -118,7 +118,9 @@ class LiveActivityManager {
 
     print("🛑 Ending Live Activity")
     Task {
-      await activity.end(dismissalPolicy: .immediate)
+      let endState = activity.content.state
+      let endContent = ActivityContent(state: endState, staleDate: nil)
+      await activity.end(endContent, dismissalPolicy: .immediate)
       currentActivity = nil
       print("✅ Live Activity ended successfully")
     }
@@ -137,3 +139,4 @@ class LiveActivityManager {
     return overtime > Date() ? overtime : nil
   }
 }
+

--- a/SubTimer/Views/Components/Players/ActivePlayerRowView.swift
+++ b/SubTimer/Views/Components/Players/ActivePlayerRowView.swift
@@ -18,32 +18,31 @@ struct ActivePlayerRowView: View {
     // MARK: - Body
 
     var body: some View {
-        Button(action: onTap) {
-            HStack {
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Text(player.name)
-                            .font(.headline)
-                        if isNextToSubOut {
-                            Image(systemName: "arrow.down.circle.fill")
-                                .foregroundStyle(.appOrange)
-                                .font(.caption)
-                        }
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(player.name)
+                        .font(.headline)
+                    if isNextToSubOut {
+                        Image(systemName: "arrow.down.circle.fill")
+                            .foregroundStyle(.appOrange)
+                            .font(.caption)
                     }
-                    Text(TimeFormatter.format(player.currentPlayDuration))
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
                 }
-
-                Spacer()
-
-                Image(systemName: "ellipsis.circle")
-                    .foregroundStyle(.appPurple)
+                Text(TimeFormatter.format(player.currentPlayDuration))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
             }
-            .padding()
+
+            Spacer()
+
+            Image(systemName: "ellipsis.circle")
+                .foregroundStyle(.appPurple)
         }
-        .buttonStyle(.plain)
+        .padding()
+        .contentShape(Rectangle())
+        .onLongPressGesture(minimumDuration: 0.5) { onTap() }
         .accessibilityIdentifier("player.row.active")
     }
 }

--- a/SubTimer/Views/Components/Players/ActivePlayerRowView.swift
+++ b/SubTimer/Views/Components/Players/ActivePlayerRowView.swift
@@ -39,10 +39,12 @@ struct ActivePlayerRowView: View {
         }
         .padding()
         .contentShape(Rectangle())
-        .simultaneousGesture(
-            LongPressGesture(minimumDuration: 0.5)
-                .onEnded { _ in onTap() }
-        )
+        .swipeActions(edge: .trailing) {
+            Button { onTap() } label: {
+                Label("Actions", systemImage: "ellipsis.circle")
+            }
+            .tint(.appPurple)
+        }
         .accessibilityIdentifier("player.row.active")
     }
 }

--- a/SubTimer/Views/Components/Players/ActivePlayerRowView.swift
+++ b/SubTimer/Views/Components/Players/ActivePlayerRowView.swift
@@ -36,13 +36,13 @@ struct ActivePlayerRowView: View {
             }
 
             Spacer()
-
-            Image(systemName: "ellipsis.circle")
-                .foregroundStyle(.appPurple)
         }
         .padding()
         .contentShape(Rectangle())
-        .onLongPressGesture(minimumDuration: 0.5) { onTap() }
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.5)
+                .onEnded { _ in onTap() }
+        )
         .accessibilityIdentifier("player.row.active")
     }
 }

--- a/SubTimer/Views/Components/Players/ActivePlayerRowView.swift
+++ b/SubTimer/Views/Components/Players/ActivePlayerRowView.swift
@@ -36,15 +36,15 @@ struct ActivePlayerRowView: View {
             }
 
             Spacer()
+
+            Button(action: onTap) {
+                Image(systemName: "ellipsis.circle")
+                    .font(.title2)
+                    .foregroundStyle(.appPurple)
+            }
+            .buttonStyle(.plain)
         }
         .padding()
-        .contentShape(Rectangle())
-        .swipeActions(edge: .trailing) {
-            Button { onTap() } label: {
-                Label("Actions", systemImage: "ellipsis.circle")
-            }
-            .tint(.appPurple)
-        }
         .accessibilityIdentifier("player.row.active")
     }
 }

--- a/SubTimer/Views/Components/Players/BenchPlayerRowView.swift
+++ b/SubTimer/Views/Components/Players/BenchPlayerRowView.swift
@@ -20,39 +20,53 @@ struct BenchPlayerRowView: View {
     // MARK: - Body
 
     var body: some View {
-        Button(action: onTap) {
-            HStack {
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Text(player.name)
-                            .font(.headline)
-                        if isNextUp && !canActivate {
-                            Image(systemName: "arrow.up.circle.fill")
-                                .foregroundStyle(.green)
-                                .font(.caption)
-                        }
-                    }
-                    Text("Total: \(TimeFormatter.format(player.totalPlayTime))")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                }
-
-                Spacer()
-
-                if canActivate {
-                    Button(action: onActivate) {
-                        Image(systemName: "plus.circle.fill")
-                            .font(.title2)
-                            .foregroundStyle(.green)
-                    }
-                }
-            }
-            .padding()
-            .cornerRadius(8)
+        if canActivate {
+            rowContent
+                .contentShape(Rectangle())
+                .onLongPressGesture(minimumDuration: 0.5) { onTap() }
+                .accessibilityIdentifier("player.row.bench")
+        } else {
+            rowContent
+                .contentShape(Rectangle())
+                .onTapGesture { onTap() }
+                .onLongPressGesture(minimumDuration: 0.5) { onTap() }
+                .accessibilityIdentifier("player.row.bench")
         }
-        .buttonStyle(.plain)
-        .accessibilityIdentifier("player.row.bench")
+    }
+
+    // MARK: - Row Content
+
+    private var rowContent: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(player.name)
+                        .font(.headline)
+                    if isNextUp && !canActivate {
+                        Image(systemName: "arrow.up.circle.fill")
+                            .foregroundStyle(.green)
+                            .font(.caption)
+                    }
+                }
+                Text("Total: \(TimeFormatter.format(player.totalPlayTime))")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+
+            Spacer()
+
+            if canActivate {
+                Button(action: onActivate) {
+                    Image(systemName: "plus.circle.fill")
+                        .font(.title2)
+                        .foregroundStyle(.green)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding()
+        .cornerRadius(8)
     }
 }
 

--- a/SubTimer/Views/Components/Players/BenchPlayerRowView.swift
+++ b/SubTimer/Views/Components/Players/BenchPlayerRowView.swift
@@ -23,13 +23,19 @@ struct BenchPlayerRowView: View {
         if canActivate {
             rowContent
                 .contentShape(Rectangle())
-                .onLongPressGesture(minimumDuration: 0.5) { onTap() }
+                .simultaneousGesture(
+                    LongPressGesture(minimumDuration: 0.5)
+                        .onEnded { _ in onTap() }
+                )
                 .accessibilityIdentifier("player.row.bench")
         } else {
             rowContent
                 .contentShape(Rectangle())
                 .onTapGesture { onTap() }
-                .onLongPressGesture(minimumDuration: 0.5) { onTap() }
+                .simultaneousGesture(
+                    LongPressGesture(minimumDuration: 0.5)
+                        .onEnded { _ in onTap() }
+                )
                 .accessibilityIdentifier("player.row.bench")
         }
     }

--- a/SubTimer/Views/Components/Players/BenchPlayerRowView.swift
+++ b/SubTimer/Views/Components/Players/BenchPlayerRowView.swift
@@ -23,19 +23,23 @@ struct BenchPlayerRowView: View {
         if canActivate {
             rowContent
                 .contentShape(Rectangle())
-                .simultaneousGesture(
-                    LongPressGesture(minimumDuration: 0.5)
-                        .onEnded { _ in onTap() }
-                )
+                .swipeActions(edge: .trailing) {
+                    Button { onTap() } label: {
+                        Label("Actions", systemImage: "ellipsis.circle")
+                    }
+                    .tint(.appPurple)
+                }
                 .accessibilityIdentifier("player.row.bench")
         } else {
             rowContent
                 .contentShape(Rectangle())
                 .onTapGesture { onTap() }
-                .simultaneousGesture(
-                    LongPressGesture(minimumDuration: 0.5)
-                        .onEnded { _ in onTap() }
-                )
+                .swipeActions(edge: .trailing) {
+                    Button { onTap() } label: {
+                        Label("Actions", systemImage: "ellipsis.circle")
+                    }
+                    .tint(.appPurple)
+                }
                 .accessibilityIdentifier("player.row.bench")
         }
     }

--- a/SubTimer/Views/Components/Players/BenchPlayerRowView.swift
+++ b/SubTimer/Views/Components/Players/BenchPlayerRowView.swift
@@ -20,28 +20,8 @@ struct BenchPlayerRowView: View {
     // MARK: - Body
 
     var body: some View {
-        if canActivate {
-            rowContent
-                .contentShape(Rectangle())
-                .swipeActions(edge: .trailing) {
-                    Button { onTap() } label: {
-                        Label("Actions", systemImage: "ellipsis.circle")
-                    }
-                    .tint(.appPurple)
-                }
-                .accessibilityIdentifier("player.row.bench")
-        } else {
-            rowContent
-                .contentShape(Rectangle())
-                .onTapGesture { onTap() }
-                .swipeActions(edge: .trailing) {
-                    Button { onTap() } label: {
-                        Label("Actions", systemImage: "ellipsis.circle")
-                    }
-                    .tint(.appPurple)
-                }
-                .accessibilityIdentifier("player.row.bench")
-        }
+        rowContent
+            .accessibilityIdentifier("player.row.bench")
     }
 
     // MARK: - Row Content
@@ -65,6 +45,13 @@ struct BenchPlayerRowView: View {
             }
 
             Spacer()
+
+            Button(action: onTap) {
+                Image(systemName: "ellipsis.circle")
+                    .font(.title2)
+                    .foregroundStyle(.appPurple)
+            }
+            .buttonStyle(.plain)
 
             if canActivate {
                 Button(action: onActivate) {


### PR DESCRIPTION
## Summary

- Remove the outer `Button` wrapper from `BenchPlayerRowView` and `ActivePlayerRowView` that caused nested-button tap interception
- Add explicit, dedicated `Button` elements within each row for specific actions (ellipsis for modal, plus for activate)
- Fix deprecated Live Activity `end` API call

## Changes

**BenchPlayerRowView:**
- Removed outer `Button(action: onTap)` wrapper — row content is now a plain `HStack`
- Added an ellipsis `⋯` button that opens the player actions modal
- Plus button remains for direct activation when `canActivate` is true
- Both buttons are sibling elements (no nesting), so tap interception is eliminated

**ActivePlayerRowView:**
- Removed outer `Button(action: onTap)` wrapper
- Added an ellipsis `⋯` button that opens the player actions modal
- Tapping the row itself does nothing — only the explicit button triggers the modal

**LiveActivityManager:**
- Updated `activity.end(dismissalPolicy:)` to non-deprecated `activity.end(_:dismissalPolicy:)` API

**No interface changes** to `BenchSectionView` or `ActivePlayersSectionView` — callback wiring is unchanged.

## Design rationale

Long press gestures and swipe actions are both incompatible with SwiftUI `List` in permanent edit mode (`.environment(\.editMode, .constant(.active))`), which is required for drag-to-reorder. Explicit `Button` elements work reliably in all List contexts. See #41 for the underlying nested-scroll architecture issue.

## Verification

- Build passes ✅
- All unit tests pass ✅

Closes #36