### PR TITLE
Configure SwiftLint and get the codebase to a clean baseline

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,59 @@
+# SwiftLint configuration for SubTimer.
+#
+# Scope: this covers every Swift source target in the project — the SubTimer
+# app, its unit/UI test targets, and the ActiveBench widget/Live Activity
+# extension. Generated/build artifacts are excluded since they aren't
+# checked in and aren't ours to lint.
+#
+# Baseline philosophy (see issue #48): start from SwiftLint's default rule
+# set plus a modest, commonly-adopted set of opt-in rules. The goal on this
+# first pass is a clean, enforceable baseline — not maximal strictness.
+# Rules can be tightened later as the codebase evolves.
+
+included:
+  - SubTimer
+  - SubTimerTests
+  - SubTimerUITests
+  - ActiveBench
+
+excluded:
+  - build
+  - DerivedData
+  - .build
+  - SubTimer.xcodeproj
+
+opt_in_rules:
+  - closure_end_indentation
+  - closure_spacing
+  - collection_alignment
+  - contains_over_filter_count
+  - contains_over_filter_is_empty
+  - contains_over_first_not_nil
+  - convenience_type
+  - discouraged_optional_boolean
+  - empty_count
+  - empty_string
+  - fallthrough
+  - first_where
+  - identical_operands
+  - joined_default_parameter
+  - last_where
+  - legacy_random
+  - literal_expression_end_indentation
+  - modifier_order
+  - operator_usage_whitespace
+  - overridden_super_call
+  - pattern_matching_keywords
+  - prefer_self_type_over_type_of_self
+  - redundant_nil_coalescing
+  - redundant_type_annotation
+  - sorted_first_last
+  - sorted_imports
+  - toggle_bool
+  - unavailable_function
+  - unneeded_parentheses_in_closure_argument
+  - vertical_whitespace_closing_braces
+  - vertical_whitespace_opening_braces
+  - yoda_condition
+
+

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -36,6 +36,7 @@ opt_in_rules:
   - fallthrough
   - first_where
   - identical_operands
+  - indentation_width
   - joined_default_parameter
   - last_where
   - legacy_random

--- a/ActiveBench/ActiveBenchAttributes.swift
+++ b/ActiveBench/ActiveBenchAttributes.swift
@@ -13,29 +13,29 @@ import Foundation
 /// Activity attributes for the SubTimer Live Activity
 /// Defines the structure for timer state displayed on lock screen and Dynamic Island
 struct ActiveBenchAttributes: ActivityAttributes {
-  /// Dynamic state that changes during the activity
-  public struct ContentState: Codable, Hashable {
-    // Timer state properties
-    var isRunning: Bool
-    var timerStartDate: Date
-    var accumulatedTime: TimeInterval
-    var preferredPlayTimeSeconds: Int
+    /// Dynamic state that changes during the activity
+    public struct ContentState: Codable, Hashable {
+        // Timer state properties
+        var isRunning: Bool
+        var timerStartDate: Date
+        var accumulatedTime: TimeInterval
+        var preferredPlayTimeSeconds: Int
 
-    // Player counts
-    var activePlayersCount: Int
-    var benchedPlayersCount: Int
+        // Player counts
+        var activePlayersCount: Int
+        var benchedPlayersCount: Int
 
-    // Substitution recommendation
-    var subOutPlayerName: String?
-    var subInPlayerName: String?
+        // Substitution recommendation
+        var subOutPlayerName: String?
+        var subInPlayerName: String?
 
-    /// Virtual reference date (`timerStartDate - accumulatedTime`) that lets
-    /// `Text(date, style: .timer)` show the total elapsed time while running.
-    var timerRefDate: Date {
-      timerStartDate.addingTimeInterval(-accumulatedTime)
+        /// Virtual reference date (`timerStartDate - accumulatedTime`) that lets
+        /// `Text(date, style: .timer)` show the total elapsed time while running.
+        var timerRefDate: Date {
+            timerStartDate.addingTimeInterval(-accumulatedTime)
+        }
     }
-  }
 
-  // Fixed non-changing properties about your activity
-  var sessionName: String
+    // Fixed non-changing properties about your activity
+    var sessionName: String
 }

--- a/ActiveBench/ActiveBenchLiveActivity.swift
+++ b/ActiveBench/ActiveBenchLiveActivity.swift
@@ -13,255 +13,255 @@ import WidgetKit
 // That file should be added to BOTH the main app and widget extension targets in Xcode.
 
 struct ActiveBenchLiveActivity: Widget {
-  var body: some WidgetConfiguration {
-    ActivityConfiguration(for: ActiveBenchAttributes.self) { context in
-      VStack(spacing: 12) {
-        VStack(spacing: 4) {
-          Text("Current Play Time")
-            .font(.caption)
-            .foregroundStyle(.secondary)
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: ActiveBenchAttributes.self) { context in
+            VStack(spacing: 12) {
+                VStack(spacing: 4) {
+                    Text("Current Play Time")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
 
-          HStack(alignment: .firstTextBaseline, spacing: 12) {
-            if context.state.isRunning {
-              Text(context.state.timerRefDate, style: .timer)
-                .font(.system(size: 32, weight: .bold, design: .rounded))
-                .monospacedDigit()
-                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
-            } else {
-              Text(formatTime(context.state.accumulatedTime))
-                .font(.system(size: 32, weight: .bold, design: .rounded))
-                .monospacedDigit()
-                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+                    HStack(alignment: .firstTextBaseline, spacing: 12) {
+                        if context.state.isRunning {
+                            Text(context.state.timerRefDate, style: .timer)
+                                .font(.system(size: 32, weight: .bold, design: .rounded))
+                                .monospacedDigit()
+                                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+                        } else {
+                            Text(formatTime(context.state.accumulatedTime))
+                                .font(.system(size: 32, weight: .bold, design: .rounded))
+                                .monospacedDigit()
+                                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+                        }
+
+                        if let subOut = context.state.subOutPlayerName,
+                            let subIn = context.state.subInPlayerName {
+                            Text("\(subOut) → \(subIn)")
+                                .font(.system(size: 16, weight: .semibold, design: .rounded))
+                                .foregroundStyle(Color("AppOrange"))
+                                .lineLimit(1)
+                        }
+                    }
+                }
+
+                HStack(spacing: 16) {
+                    Image(systemName: context.state.isRunning ? "play.circle.fill" : "pause.circle.fill")
+                        .foregroundStyle(context.state.isRunning ? .green : Color("AppOrange"))
+
+                    HStack(spacing: 4) {
+                        Image(systemName: "person.3.fill")
+                        Text("\(context.state.activePlayersCount) Active")
+                    }
+
+                    HStack(spacing: 4) {
+                        Image(systemName: "figure.seated")
+                        Text("\(context.state.benchedPlayersCount) Bench")
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
             }
+            .padding()
+            .activityBackgroundTint(Color(uiColor: .systemBackground))
+            .activitySystemActionForegroundColor(Color.primary)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    HStack(spacing: 12) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "person.3.fill")
+                            Text("\(context.state.activePlayersCount)")
+                        }
 
-            if let subOut = context.state.subOutPlayerName,
-              let subIn = context.state.subInPlayerName {
-              Text("\(subOut) → \(subIn)")
-                .font(.system(size: 16, weight: .semibold, design: .rounded))
-                .foregroundStyle(Color("AppOrange"))
-                .lineLimit(1)
+                        HStack(spacing: 4) {
+                            Image(systemName: "figure.seated")
+                            Text("\(context.state.benchedPlayersCount)")
+                        }
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+
+                DynamicIslandExpandedRegion(.bottom) {
+                    VStack(spacing: 4) {
+                        if context.state.isRunning {
+                            Text(context.state.timerRefDate, style: .timer)
+                                .font(.system(size: 36, weight: .bold, design: .rounded))
+                                .monospacedDigit()
+                                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+                        } else {
+                            Text(formatTime(context.state.accumulatedTime))
+                                .font(.system(size: 36, weight: .bold, design: .rounded))
+                                .monospacedDigit()
+                                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+                        }
+
+                        if let subOut = context.state.subOutPlayerName,
+                            let subIn = context.state.subInPlayerName {
+                            Text("\(subOut) → \(subIn)")
+                                .font(.system(size: 20, weight: .semibold, design: .rounded))
+                                .foregroundStyle(Color("AppOrange"))
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.7)
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+            } compactLeading: {
+                HStack(spacing: 2) {
+                    Image(systemName: context.state.isRunning ? "play.fill" : "pause.fill")
+                        .font(.caption2)
+                    if context.state.isRunning {
+                        Text(context.state.timerRefDate, style: .timer)
+                            .font(.caption2)
+                            .monospacedDigit()
+                            .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+                    } else {
+                        Text(formatTimeCompact(context.state.accumulatedTime))
+                            .font(.caption2)
+                            .monospacedDigit()
+                            .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+                    }
+                }
+            } compactTrailing: {
+                if let subOut = context.state.subOutPlayerName,
+                    let subIn = context.state.subInPlayerName {
+                    Text("\(subOut) → \(subIn)")
+                        .font(.system(size: 12))
+                        .foregroundStyle(Color("AppOrange"))
+                        .lineLimit(1)
+                }
+            } minimal: {
+                Image(systemName: context.state.isRunning ? "play.circle.fill" : "pause.circle.fill")
+                    .foregroundStyle(context.state.isRunning ? .green : Color("AppOrange"))
             }
-          }
+            .keylineTint(context.state.isRunning ? .green : Color("AppOrange"))
         }
-
-        HStack(spacing: 16) {
-          Image(systemName: context.state.isRunning ? "play.circle.fill" : "pause.circle.fill")
-            .foregroundStyle(context.state.isRunning ? .green : Color("AppOrange"))
-
-          HStack(spacing: 4) {
-            Image(systemName: "person.3.fill")
-            Text("\(context.state.activePlayersCount) Active")
-          }
-
-          HStack(spacing: 4) {
-            Image(systemName: "figure.seated")
-            Text("\(context.state.benchedPlayersCount) Bench")
-          }
-        }
-        .font(.caption)
-        .foregroundStyle(.secondary)
-      }
-      .padding()
-      .activityBackgroundTint(Color(uiColor: .systemBackground))
-      .activitySystemActionForegroundColor(Color.primary)
-    } dynamicIsland: { context in
-      DynamicIsland {
-        DynamicIslandExpandedRegion(.leading) {
-          HStack(spacing: 12) {
-            HStack(spacing: 4) {
-              Image(systemName: "person.3.fill")
-              Text("\(context.state.activePlayersCount)")
-            }
-
-            HStack(spacing: 4) {
-              Image(systemName: "figure.seated")
-              Text("\(context.state.benchedPlayersCount)")
-            }
-          }
-          .font(.caption)
-          .foregroundStyle(.secondary)
-        }
-
-        DynamicIslandExpandedRegion(.bottom) {
-          VStack(spacing: 4) {
-            if context.state.isRunning {
-              Text(context.state.timerRefDate, style: .timer)
-                .font(.system(size: 36, weight: .bold, design: .rounded))
-                .monospacedDigit()
-                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
-            } else {
-              Text(formatTime(context.state.accumulatedTime))
-                .font(.system(size: 36, weight: .bold, design: .rounded))
-                .monospacedDigit()
-                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
-            }
-
-            if let subOut = context.state.subOutPlayerName,
-              let subIn = context.state.subInPlayerName {
-              Text("\(subOut) → \(subIn)")
-                .font(.system(size: 20, weight: .semibold, design: .rounded))
-                .foregroundStyle(Color("AppOrange"))
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-            }
-          }
-          .frame(maxWidth: .infinity)
-        }
-      } compactLeading: {
-        HStack(spacing: 2) {
-          Image(systemName: context.state.isRunning ? "play.fill" : "pause.fill")
-            .font(.caption2)
-          if context.state.isRunning {
-            Text(context.state.timerRefDate, style: .timer)
-              .font(.caption2)
-              .monospacedDigit()
-              .foregroundStyle(isOvertime(context.state) ? .red : .primary)
-          } else {
-            Text(formatTimeCompact(context.state.accumulatedTime))
-              .font(.caption2)
-              .monospacedDigit()
-              .foregroundStyle(isOvertime(context.state) ? .red : .primary)
-          }
-        }
-      } compactTrailing: {
-        if let subOut = context.state.subOutPlayerName,
-          let subIn = context.state.subInPlayerName {
-          Text("\(subOut) → \(subIn)")
-            .font(.system(size: 12))
-            .foregroundStyle(Color("AppOrange"))
-            .lineLimit(1)
-        }
-      } minimal: {
-        Image(systemName: context.state.isRunning ? "play.circle.fill" : "pause.circle.fill")
-          .foregroundStyle(context.state.isRunning ? .green : Color("AppOrange"))
-      }
-      .keylineTint(context.state.isRunning ? .green : Color("AppOrange"))
     }
-  }
 
-  // MARK: - Helper Functions
+    // MARK: - Helper Functions
 
-  private func overtimeDate(_ state: ActiveBenchAttributes.ContentState) -> Date {
-    state.timerRefDate.addingTimeInterval(TimeInterval(state.preferredPlayTimeSeconds))
-  }
-
-  private func formatTime(_ timeInterval: TimeInterval) -> String {
-    let totalSeconds = Int(timeInterval)
-    let hours = totalSeconds / 3600
-    let minutes = (totalSeconds % 3600) / 60
-    let seconds = totalSeconds % 60
-
-    if hours > 0 {
-      return String(format: "%d:%02d:%02d", hours, minutes, seconds)
-    } else {
-      return String(format: "%d:%02d", minutes, seconds)
+    private func overtimeDate(_ state: ActiveBenchAttributes.ContentState) -> Date {
+        state.timerRefDate.addingTimeInterval(TimeInterval(state.preferredPlayTimeSeconds))
     }
-  }
 
-  private func formatTimeCompact(_ timeInterval: TimeInterval) -> String {
-    let totalSeconds = Int(timeInterval)
-    let minutes = totalSeconds / 60
-    let seconds = totalSeconds % 60
-    return String(format: "%d:%02d", minutes, seconds)
-  }
+    private func formatTime(_ timeInterval: TimeInterval) -> String {
+        let totalSeconds = Int(timeInterval)
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
 
-  private func isOvertime(_ state: ActiveBenchAttributes.ContentState) -> Bool {
-    guard state.preferredPlayTimeSeconds > 0 else { return false }
-    if state.isRunning {
-      let elapsed = Date().timeIntervalSince(state.timerRefDate)
-      return elapsed > TimeInterval(state.preferredPlayTimeSeconds)
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        } else {
+            return String(format: "%d:%02d", minutes, seconds)
+        }
     }
-    return state.accumulatedTime > TimeInterval(state.preferredPlayTimeSeconds)
-  }
 
-  private func timeRemainingText(_ state: ActiveBenchAttributes.ContentState) -> String {
-    let timeRemaining = TimeInterval(state.preferredPlayTimeSeconds) - state.accumulatedTime
-
-    if timeRemaining < 0 {
-      return "Over by \(formatTimeCompact(abs(timeRemaining)))"
-    } else {
-      return "Preferred: \(formatTimeCompact(TimeInterval(state.preferredPlayTimeSeconds)))"
+    private func formatTimeCompact(_ timeInterval: TimeInterval) -> String {
+        let totalSeconds = Int(timeInterval)
+        let minutes = totalSeconds / 60
+        let seconds = totalSeconds % 60
+        return String(format: "%d:%02d", minutes, seconds)
     }
-  }
+
+    private func isOvertime(_ state: ActiveBenchAttributes.ContentState) -> Bool {
+        guard state.preferredPlayTimeSeconds > 0 else { return false }
+        if state.isRunning {
+            let elapsed = Date().timeIntervalSince(state.timerRefDate)
+            return elapsed > TimeInterval(state.preferredPlayTimeSeconds)
+        }
+        return state.accumulatedTime > TimeInterval(state.preferredPlayTimeSeconds)
+    }
+
+    private func timeRemainingText(_ state: ActiveBenchAttributes.ContentState) -> String {
+        let timeRemaining = TimeInterval(state.preferredPlayTimeSeconds) - state.accumulatedTime
+
+        if timeRemaining < 0 {
+            return "Over by \(formatTimeCompact(abs(timeRemaining)))"
+        } else {
+            return "Preferred: \(formatTimeCompact(TimeInterval(state.preferredPlayTimeSeconds)))"
+        }
+    }
 }
 
 // MARK: - Previews
 
 extension ActiveBenchAttributes {
-  fileprivate static var preview: ActiveBenchAttributes {
-    ActiveBenchAttributes(sessionName: "Practice Session")
-  }
+    fileprivate static var preview: ActiveBenchAttributes {
+        ActiveBenchAttributes(sessionName: "Practice Session")
+    }
 }
 
 extension ActiveBenchAttributes.ContentState {
-  fileprivate static var running: ActiveBenchAttributes.ContentState {
-    ActiveBenchAttributes.ContentState(
-      isRunning: true,
-      timerStartDate: Date().addingTimeInterval(-120),
-      accumulatedTime: 0,
-      preferredPlayTimeSeconds: 180,
-      activePlayersCount: 5,
-      benchedPlayersCount: 3,
-      subOutPlayerName: "Alice",
-      subInPlayerName: "Bob"
-    )
-  }
+    fileprivate static var running: ActiveBenchAttributes.ContentState {
+        ActiveBenchAttributes.ContentState(
+            isRunning: true,
+            timerStartDate: Date().addingTimeInterval(-120),
+            accumulatedTime: 0,
+            preferredPlayTimeSeconds: 180,
+            activePlayersCount: 5,
+            benchedPlayersCount: 3,
+            subOutPlayerName: "Alice",
+            subInPlayerName: "Bob"
+        )
+    }
 
-  fileprivate static var paused: ActiveBenchAttributes.ContentState {
-    ActiveBenchAttributes.ContentState(
-      isRunning: false,
-      timerStartDate: Date(),
-      accumulatedTime: 90,
-      preferredPlayTimeSeconds: 180,
-      activePlayersCount: 5,
-      benchedPlayersCount: 3,
-      subOutPlayerName: "Alice",
-      subInPlayerName: "Bob"
-    )
-  }
+    fileprivate static var paused: ActiveBenchAttributes.ContentState {
+        ActiveBenchAttributes.ContentState(
+            isRunning: false,
+            timerStartDate: Date(),
+            accumulatedTime: 90,
+            preferredPlayTimeSeconds: 180,
+            activePlayersCount: 5,
+            benchedPlayersCount: 3,
+            subOutPlayerName: "Alice",
+            subInPlayerName: "Bob"
+        )
+    }
 
-  fileprivate static var overtime: ActiveBenchAttributes.ContentState {
-    ActiveBenchAttributes.ContentState(
-      isRunning: true,
-      timerStartDate: Date().addingTimeInterval(-240),
-      accumulatedTime: 0,
-      preferredPlayTimeSeconds: 180,
-      activePlayersCount: 4,
-      benchedPlayersCount: 4,
-      subOutPlayerName: "Charlie",
-      subInPlayerName: "Diana"
-    )
-  }
+    fileprivate static var overtime: ActiveBenchAttributes.ContentState {
+        ActiveBenchAttributes.ContentState(
+            isRunning: true,
+            timerStartDate: Date().addingTimeInterval(-240),
+            accumulatedTime: 0,
+            preferredPlayTimeSeconds: 180,
+            activePlayersCount: 4,
+            benchedPlayersCount: 4,
+            subOutPlayerName: "Charlie",
+            subInPlayerName: "Diana"
+        )
+    }
 }
 
 #Preview("Notification", as: .content, using: ActiveBenchAttributes.preview) {
-  ActiveBenchLiveActivity()
+    ActiveBenchLiveActivity()
 } contentStates: {
-  ActiveBenchAttributes.ContentState.running
-  ActiveBenchAttributes.ContentState.paused
-  ActiveBenchAttributes.ContentState.overtime
+    ActiveBenchAttributes.ContentState.running
+    ActiveBenchAttributes.ContentState.paused
+    ActiveBenchAttributes.ContentState.overtime
 }
 
 #Preview("Dynamic Island Expanded", as: .dynamicIsland(.expanded), using: ActiveBenchAttributes.preview) {
-  ActiveBenchLiveActivity()
+    ActiveBenchLiveActivity()
 } contentStates: {
-  ActiveBenchAttributes.ContentState.running
-  ActiveBenchAttributes.ContentState.paused
-  ActiveBenchAttributes.ContentState.overtime
+    ActiveBenchAttributes.ContentState.running
+    ActiveBenchAttributes.ContentState.paused
+    ActiveBenchAttributes.ContentState.overtime
 }
 
 #Preview("Dynamic Island Compact", as: .dynamicIsland(.compact), using: ActiveBenchAttributes.preview) {
-  ActiveBenchLiveActivity()
+    ActiveBenchLiveActivity()
 } contentStates: {
-  ActiveBenchAttributes.ContentState.running
-  ActiveBenchAttributes.ContentState.paused
-  ActiveBenchAttributes.ContentState.overtime
+    ActiveBenchAttributes.ContentState.running
+    ActiveBenchAttributes.ContentState.paused
+    ActiveBenchAttributes.ContentState.overtime
 }
 
 #Preview("Dynamic Island Minimal", as: .dynamicIsland(.minimal), using: ActiveBenchAttributes.preview) {
-  ActiveBenchLiveActivity()
+    ActiveBenchLiveActivity()
 } contentStates: {
-  ActiveBenchAttributes.ContentState.running
-  ActiveBenchAttributes.ContentState.paused
-  ActiveBenchAttributes.ContentState.overtime
+    ActiveBenchAttributes.ContentState.running
+    ActiveBenchAttributes.ContentState.paused
+    ActiveBenchAttributes.ContentState.overtime
 }

--- a/ActiveBench/ActiveBenchLiveActivity.swift
+++ b/ActiveBench/ActiveBenchLiveActivity.swift
@@ -35,8 +35,7 @@ struct ActiveBenchLiveActivity: Widget {
             }
 
             if let subOut = context.state.subOutPlayerName,
-              let subIn = context.state.subInPlayerName
-            {
+              let subIn = context.state.subInPlayerName {
               Text("\(subOut) → \(subIn)")
                 .font(.system(size: 16, weight: .semibold, design: .rounded))
                 .foregroundStyle(Color("AppOrange"))
@@ -65,7 +64,6 @@ struct ActiveBenchLiveActivity: Widget {
       .padding()
       .activityBackgroundTint(Color(uiColor: .systemBackground))
       .activitySystemActionForegroundColor(Color.primary)
-
     } dynamicIsland: { context in
       DynamicIsland {
         DynamicIslandExpandedRegion(.leading) {
@@ -99,8 +97,7 @@ struct ActiveBenchLiveActivity: Widget {
             }
 
             if let subOut = context.state.subOutPlayerName,
-              let subIn = context.state.subInPlayerName
-            {
+              let subIn = context.state.subInPlayerName {
               Text("\(subOut) → \(subIn)")
                 .font(.system(size: 20, weight: .semibold, design: .rounded))
                 .foregroundStyle(Color("AppOrange"))
@@ -128,8 +125,7 @@ struct ActiveBenchLiveActivity: Widget {
         }
       } compactTrailing: {
         if let subOut = context.state.subOutPlayerName,
-          let subIn = context.state.subInPlayerName
-        {
+          let subIn = context.state.subInPlayerName {
           Text("\(subOut) → \(subIn)")
             .font(.system(size: 12))
             .foregroundStyle(Color("AppOrange"))

--- a/README.md
+++ b/README.md
@@ -1,5 +1,34 @@
 # SubTimer
 
+## Linting
+
+Swift source is linted with [SwiftLint](https://github.com/realm/SwiftLint),
+configured in [`.swiftlint.yml`](./.swiftlint.yml) at the repo root. It
+covers `SubTimer/`, `SubTimerTests/`, `SubTimerUITests/`, and `ActiveBench/`.
+
+### Install
+
+```bash
+brew install swiftlint
+```
+
+### Run
+
+From the repo root:
+
+```bash
+swiftlint lint --strict
+```
+
+`--strict` treats warnings as failures, matching what CI enforces.
+
+To auto-fix what's mechanically correctable (spacing, trailing commas,
+`isEmpty` vs. `count == 0`, etc.) before addressing anything left by hand:
+
+```bash
+swiftlint --fix
+```
+
 ## Running tests from the command line
 
 This is an Xcode project, so tests run via `xcodebuild test` rather than a

--- a/SubTimer/Models/OrderManager.swift
+++ b/SubTimer/Models/OrderManager.swift
@@ -87,4 +87,9 @@ final class OrderManager {
     var count: Int {
         return playerOrder.count
     }
+
+    /// Returns whether the order has no players
+    var isEmpty: Bool {
+        return playerOrder.isEmpty
+    }
 }

--- a/SubTimer/SubTimerApp.swift
+++ b/SubTimer/SubTimerApp.swift
@@ -15,7 +15,7 @@ struct SubTimerApp: App {
             Player.self,
             AppConfiguration.self,
             Session.self,
-            OrderManager.self,
+            OrderManager.self
         ])
 
         // Use in-memory storage for UI testing

--- a/SubTimer/Utilities/LiveActivityManager.swift
+++ b/SubTimer/Utilities/LiveActivityManager.swift
@@ -13,135 +13,135 @@ import Foundation
 /// Manages the Live Activity for displaying timer state on lock screen and Dynamic Island
 @available(iOS 16.2, *)
 class LiveActivityManager {
-  static let shared = LiveActivityManager()
+    static let shared = LiveActivityManager()
 
-  private var currentActivity: Activity<ActiveBenchAttributes>?
+    private var currentActivity: Activity<ActiveBenchAttributes>?
 
-  private init() {}
+    private init() {}
 
-  // Mirrors ActivityKit's own `ActivityContent`/attribute shape; bundling
-  // these into a struct would just move the same 7 fields one level over.
-  // swiftlint:disable:next function_parameter_count
-  func startActivity(
-    sessionName: String,
-    isRunning: Bool,
-    timerStartDate: Date,
-    accumulatedTime: TimeInterval,
-    preferredPlayTimeSeconds: Int,
-    activePlayersCount: Int,
-    benchedPlayersCount: Int,
-    subOutPlayerName: String? = nil,
-    subInPlayerName: String? = nil
-  ) {
-    guard ActivityAuthorizationInfo().areActivitiesEnabled else {
-      print("⚠️ Live Activities are not enabled")
-      return
-    }
+    // Mirrors ActivityKit's own `ActivityContent`/attribute shape; bundling
+    // these into a struct would just move the same 7 fields one level over.
+    // swiftlint:disable:next function_parameter_count
+    func startActivity(
+        sessionName: String,
+        isRunning: Bool,
+        timerStartDate: Date,
+        accumulatedTime: TimeInterval,
+        preferredPlayTimeSeconds: Int,
+        activePlayersCount: Int,
+        benchedPlayersCount: Int,
+        subOutPlayerName: String? = nil,
+        subInPlayerName: String? = nil
+    ) {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+            print("⚠️ Live Activities are not enabled")
+            return
+        }
 
-    if currentActivity != nil {
-      updateActivity(
-        isRunning: isRunning,
-        timerStartDate: timerStartDate,
-        accumulatedTime: accumulatedTime,
-        preferredPlayTimeSeconds: preferredPlayTimeSeconds,
-        activePlayersCount: activePlayersCount,
-        benchedPlayersCount: benchedPlayersCount,
-        subOutPlayerName: subOutPlayerName,
-        subInPlayerName: subInPlayerName
-      )
-      return
-    }
+        if currentActivity != nil {
+            updateActivity(
+                isRunning: isRunning,
+                timerStartDate: timerStartDate,
+                accumulatedTime: accumulatedTime,
+                preferredPlayTimeSeconds: preferredPlayTimeSeconds,
+                activePlayersCount: activePlayersCount,
+                benchedPlayersCount: benchedPlayersCount,
+                subOutPlayerName: subOutPlayerName,
+                subInPlayerName: subInPlayerName
+            )
+            return
+        }
 
-    let contentState = ActiveBenchAttributes.ContentState(
-      isRunning: isRunning,
-      timerStartDate: timerStartDate,
-      accumulatedTime: accumulatedTime,
-      preferredPlayTimeSeconds: preferredPlayTimeSeconds,
-      activePlayersCount: activePlayersCount,
-      benchedPlayersCount: benchedPlayersCount,
-      subOutPlayerName: subOutPlayerName,
-      subInPlayerName: subInPlayerName
-    )
-
-    do {
-      let staleDate = computeStaleDate(
-        isRunning: isRunning, timerRefDate: contentState.timerRefDate,
-        preferredPlayTimeSeconds: preferredPlayTimeSeconds)
-      currentActivity = try Activity.request(
-        attributes: ActiveBenchAttributes(sessionName: sessionName),
-        content: ActivityContent(state: contentState, staleDate: staleDate)
-      )
-    } catch {
-      print("❌ Error starting Live Activity: \(error.localizedDescription)")
-    }
-  }
-
-  // Same state shape as `startActivity`, minus `sessionName` (set once at
-  // start and immutable for the Live Activity's lifetime).
-  // swiftlint:disable:next function_parameter_count
-  func updateActivity(
-    isRunning: Bool,
-    timerStartDate: Date,
-    accumulatedTime: TimeInterval,
-    preferredPlayTimeSeconds: Int,
-    activePlayersCount: Int,
-    benchedPlayersCount: Int,
-    subOutPlayerName: String? = nil,
-    subInPlayerName: String? = nil
-  ) {
-    guard let activity = currentActivity else { return }
-
-    let contentState = ActiveBenchAttributes.ContentState(
-      isRunning: isRunning,
-      timerStartDate: timerStartDate,
-      accumulatedTime: accumulatedTime,
-      preferredPlayTimeSeconds: preferredPlayTimeSeconds,
-      activePlayersCount: activePlayersCount,
-      benchedPlayersCount: benchedPlayersCount,
-      subOutPlayerName: subOutPlayerName,
-      subInPlayerName: subInPlayerName
-    )
-
-    Task {
-      let staleDate = computeStaleDate(
-        isRunning: isRunning, timerRefDate: contentState.timerRefDate,
-        preferredPlayTimeSeconds: preferredPlayTimeSeconds)
-      await activity.update(
-        ActivityContent(
-          state: contentState,
-          staleDate: staleDate
+        let contentState = ActiveBenchAttributes.ContentState(
+            isRunning: isRunning,
+            timerStartDate: timerStartDate,
+            accumulatedTime: accumulatedTime,
+            preferredPlayTimeSeconds: preferredPlayTimeSeconds,
+            activePlayersCount: activePlayersCount,
+            benchedPlayersCount: benchedPlayersCount,
+            subOutPlayerName: subOutPlayerName,
+            subInPlayerName: subInPlayerName
         )
-      )
+
+        do {
+            let staleDate = computeStaleDate(
+                isRunning: isRunning, timerRefDate: contentState.timerRefDate,
+                preferredPlayTimeSeconds: preferredPlayTimeSeconds)
+            currentActivity = try Activity.request(
+                attributes: ActiveBenchAttributes(sessionName: sessionName),
+                content: ActivityContent(state: contentState, staleDate: staleDate)
+            )
+        } catch {
+            print("❌ Error starting Live Activity: \(error.localizedDescription)")
+        }
     }
-  }
 
-  /// Ends the current Live Activity
-  func endActivity() {
-    guard let activity = currentActivity else {
-      print("ℹ️ No Live Activity to end")
-      return
+    // Same state shape as `startActivity`, minus `sessionName` (set once at
+    // start and immutable for the Live Activity's lifetime).
+    // swiftlint:disable:next function_parameter_count
+    func updateActivity(
+        isRunning: Bool,
+        timerStartDate: Date,
+        accumulatedTime: TimeInterval,
+        preferredPlayTimeSeconds: Int,
+        activePlayersCount: Int,
+        benchedPlayersCount: Int,
+        subOutPlayerName: String? = nil,
+        subInPlayerName: String? = nil
+    ) {
+        guard let activity = currentActivity else { return }
+
+        let contentState = ActiveBenchAttributes.ContentState(
+            isRunning: isRunning,
+            timerStartDate: timerStartDate,
+            accumulatedTime: accumulatedTime,
+            preferredPlayTimeSeconds: preferredPlayTimeSeconds,
+            activePlayersCount: activePlayersCount,
+            benchedPlayersCount: benchedPlayersCount,
+            subOutPlayerName: subOutPlayerName,
+            subInPlayerName: subInPlayerName
+        )
+
+        Task {
+            let staleDate = computeStaleDate(
+                isRunning: isRunning, timerRefDate: contentState.timerRefDate,
+                preferredPlayTimeSeconds: preferredPlayTimeSeconds)
+            await activity.update(
+                ActivityContent(
+                    state: contentState,
+                    staleDate: staleDate
+                )
+            )
+        }
     }
 
-    print("🛑 Ending Live Activity")
-    Task {
-      let endState = activity.content.state
-      let endContent = ActivityContent(state: endState, staleDate: nil)
-      await activity.end(endContent, dismissalPolicy: .immediate)
-      currentActivity = nil
-      print("✅ Live Activity ended successfully")
+    /// Ends the current Live Activity
+    func endActivity() {
+        guard let activity = currentActivity else {
+            print("ℹ️ No Live Activity to end")
+            return
+        }
+
+        print("🛑 Ending Live Activity")
+        Task {
+            let endState = activity.content.state
+            let endContent = ActivityContent(state: endState, staleDate: nil)
+            await activity.end(endContent, dismissalPolicy: .immediate)
+            currentActivity = nil
+            print("✅ Live Activity ended successfully")
+        }
     }
-  }
 
-  /// Check if there's an active Live Activity
-  var hasActiveActivity: Bool {
-    return currentActivity != nil
-  }
+    /// Check if there's an active Live Activity
+    var hasActiveActivity: Bool {
+        return currentActivity != nil
+    }
 
-  private func computeStaleDate(
-    isRunning: Bool, timerRefDate: Date, preferredPlayTimeSeconds: Int
-  ) -> Date? {
-    guard isRunning, preferredPlayTimeSeconds > 0 else { return nil }
-    let overtime = timerRefDate.addingTimeInterval(TimeInterval(preferredPlayTimeSeconds))
-    return overtime > Date() ? overtime : nil
-  }
+    private func computeStaleDate(
+        isRunning: Bool, timerRefDate: Date, preferredPlayTimeSeconds: Int
+    ) -> Date? {
+        guard isRunning, preferredPlayTimeSeconds > 0 else { return nil }
+        let overtime = timerRefDate.addingTimeInterval(TimeInterval(preferredPlayTimeSeconds))
+        return overtime > Date() ? overtime : nil
+    }
 }

--- a/SubTimer/Utilities/LiveActivityManager.swift
+++ b/SubTimer/Utilities/LiveActivityManager.swift
@@ -19,6 +19,9 @@ class LiveActivityManager {
 
   private init() {}
 
+  // Mirrors ActivityKit's own `ActivityContent`/attribute shape; bundling
+  // these into a struct would just move the same 7 fields one level over.
+  // swiftlint:disable:next function_parameter_count
   func startActivity(
     sessionName: String,
     isRunning: Bool,
@@ -73,6 +76,9 @@ class LiveActivityManager {
     }
   }
 
+  // Same state shape as `startActivity`, minus `sessionName` (set once at
+  // start and immutable for the Live Activity's lifetime).
+  // swiftlint:disable:next function_parameter_count
   func updateActivity(
     isRunning: Bool,
     timerStartDate: Date,
@@ -139,4 +145,3 @@ class LiveActivityManager {
     return overtime > Date() ? overtime : nil
   }
 }
-

--- a/SubTimer/Views/Components/Players/ActivePlayersSectionView.swift
+++ b/SubTimer/Views/Components/Players/ActivePlayersSectionView.swift
@@ -112,7 +112,7 @@ struct ActivePlayersSectionView: View {
             Player(name: "John Doe", currentPlayDuration: 120, status: .active),
             Player(name: "Jane Smith", currentPlayDuration: 180, status: .active),
             Player(name: "Mike Johnson", currentPlayDuration: 90, status: .active),
-            Player(name: "Sarah Williams", currentPlayDuration: 150, status: .active),
+            Player(name: "Sarah Williams", currentPlayDuration: 150, status: .active)
         ],
         maxActiveCount: 4,
         onPlayerTap: { player in print("Tapped: \(player.name)") },
@@ -134,7 +134,7 @@ struct ActivePlayersSectionView: View {
 #Preview("Single Player") {
     ActivePlayersSectionView(
         players: [
-            Player(name: "Solo Player", currentPlayDuration: 200, status: .active),
+            Player(name: "Solo Player", currentPlayDuration: 200, status: .active)
         ],
         maxActiveCount: 4,
         onPlayerTap: { _ in },
@@ -148,7 +148,7 @@ struct ActivePlayersSectionView: View {
         players: [
             Player(name: "Player 1", currentPlayDuration: 120, status: .active),
             Player(name: "Player 2", currentPlayDuration: 180, status: .active),
-            Player(name: "Player 3", currentPlayDuration: 90, status: .active),
+            Player(name: "Player 3", currentPlayDuration: 90, status: .active)
         ],
         maxActiveCount: 3,
         onPlayerTap: { _ in },
@@ -161,7 +161,7 @@ struct ActivePlayersSectionView: View {
     ActivePlayersSectionView(
         players: [
             Player(name: "Player 1", currentPlayDuration: 120, status: .active),
-            Player(name: "Player 2", currentPlayDuration: 180, status: .active),
+            Player(name: "Player 2", currentPlayDuration: 180, status: .active)
         ],
         maxActiveCount: 5,
         onPlayerTap: { _ in },

--- a/SubTimer/Views/Components/Players/BenchSectionView.swift
+++ b/SubTimer/Views/Components/Players/BenchSectionView.swift
@@ -118,7 +118,7 @@ struct BenchSectionView: View {
         players: [
             Player(name: "John Doe", totalPlayTime: 180, status: .benched),
             Player(name: "Jane Smith", totalPlayTime: 240, status: .benched),
-            Player(name: "Mike Johnson", totalPlayTime: 120, status: .benched),
+            Player(name: "Mike Johnson", totalPlayTime: 120, status: .benched)
         ],
         activePlayersCount: 4,
         maxActiveCount: 4,
@@ -145,7 +145,7 @@ struct BenchSectionView: View {
     BenchSectionView(
         players: [
             Player(name: "John Doe", totalPlayTime: 180, status: .benched),
-            Player(name: "Jane Smith", totalPlayTime: 240, status: .benched),
+            Player(name: "Jane Smith", totalPlayTime: 240, status: .benched)
         ],
         activePlayersCount: 2,
         maxActiveCount: 4,
@@ -160,7 +160,7 @@ struct BenchSectionView: View {
     BenchSectionView(
         players: [
             Player(name: "John Doe", totalPlayTime: 180, status: .benched),
-            Player(name: "Jane Smith", totalPlayTime: 240, status: .benched),
+            Player(name: "Jane Smith", totalPlayTime: 240, status: .benched)
         ],
         activePlayersCount: 4,
         maxActiveCount: 4,
@@ -174,7 +174,7 @@ struct BenchSectionView: View {
 #Preview("Single Bench Player") {
     BenchSectionView(
         players: [
-            Player(name: "Solo Benched", totalPlayTime: 60, status: .benched),
+            Player(name: "Solo Benched", totalPlayTime: 60, status: .benched)
         ],
         activePlayersCount: 3,
         maxActiveCount: 4,

--- a/SubTimer/Views/Components/Players/TemporarilyOutSectionView.swift
+++ b/SubTimer/Views/Components/Players/TemporarilyOutSectionView.swift
@@ -48,7 +48,7 @@ struct TemporarilyOutSectionView: View {
         players: [
             Player(name: "John Doe", totalPlayTime: 300, status: .temporarilyOut),
             Player(name: "Jane Smith", totalPlayTime: 450, status: .temporarilyOut),
-            Player(name: "Mike Johnson", totalPlayTime: 180, status: .temporarilyOut),
+            Player(name: "Mike Johnson", totalPlayTime: 180, status: .temporarilyOut)
         ],
         onReturnToBench: { player in print("Return: \(player.name)") }
     )
@@ -58,7 +58,7 @@ struct TemporarilyOutSectionView: View {
 #Preview("Single Player") {
     TemporarilyOutSectionView(
         players: [
-            Player(name: "Solo Out", totalPlayTime: 200, status: .temporarilyOut),
+            Player(name: "Solo Out", totalPlayTime: 200, status: .temporarilyOut)
         ],
         onReturnToBench: { _ in }
     )
@@ -71,7 +71,7 @@ struct TemporarilyOutSectionView: View {
             Player(name: "Player 1", totalPlayTime: 100, status: .temporarilyOut),
             Player(name: "Player 2", totalPlayTime: 500, status: .temporarilyOut),
             Player(name: "Player 3", totalPlayTime: 250, status: .temporarilyOut),
-            Player(name: "Player 4", totalPlayTime: 75, status: .temporarilyOut),
+            Player(name: "Player 4", totalPlayTime: 75, status: .temporarilyOut)
         ],
         onReturnToBench: { _ in }
     )
@@ -81,7 +81,7 @@ struct TemporarilyOutSectionView: View {
 #Preview("Zero Play Time") {
     TemporarilyOutSectionView(
         players: [
-            Player(name: "New Player Out", totalPlayTime: 0, status: .temporarilyOut),
+            Player(name: "New Player Out", totalPlayTime: 0, status: .temporarilyOut)
         ],
         onReturnToBench: { _ in }
     )

--- a/SubTimer/Views/Components/Settings/PlayerListSectionView.swift
+++ b/SubTimer/Views/Components/Settings/PlayerListSectionView.swift
@@ -52,7 +52,7 @@ struct PlayerListSectionView: View {
                 Player(name: "Alice", status: .active, sortOrder: 0),
                 Player(name: "Bob", status: .benched, sortOrder: 1),
                 Player(name: "Charlie", status: .temporarilyOut, sortOrder: 2),
-                Player(name: "Diana", status: .benched, sortOrder: 3),
+                Player(name: "Diana", status: .benched, sortOrder: 3)
             ],
             onEdit: { player in print("Edit: \(player.name)") },
             onDelete: { indices in print("Delete: \(indices)") },
@@ -78,7 +78,7 @@ struct PlayerListSectionView: View {
     Form {
         PlayerListSectionView(
             players: [
-                Player(name: "Alice", status: .active, sortOrder: 0),
+                Player(name: "Alice", status: .active, sortOrder: 0)
             ],
             onEdit: { player in print("Edit: \(player.name)") },
             onDelete: { indices in print("Delete: \(indices)") },
@@ -98,7 +98,7 @@ struct PlayerListSectionView: View {
                 Player(name: "Diana", status: .benched, sortOrder: 3),
                 Player(name: "Eve", status: .benched, sortOrder: 4),
                 Player(name: "Frank", status: .temporarilyOut, sortOrder: 5),
-                Player(name: "Grace", status: .benched, sortOrder: 6),
+                Player(name: "Grace", status: .benched, sortOrder: 6)
             ],
             onEdit: { player in print("Edit: \(player.name)") },
             onDelete: { indices in print("Delete: \(indices)") },

--- a/SubTimer/Views/Components/Settings/SessionHistoryView.swift
+++ b/SubTimer/Views/Components/Settings/SessionHistoryView.swift
@@ -100,14 +100,14 @@ struct SessionHistoryView: View {
 #Preview("Many Sessions") {
     var sessions: [Session] = []
 
-    for i in 1 ... 10 {
+    for sessionNumber in 1 ... 10 {
         let session = Session(
             preferredPlayTimeSeconds: 180,
             activePlayersCount: 4,
             playerNames: ["Player 1", "Player 2", "Player 3", "Player 4"]
         )
-        session.duration = TimeInterval(600 * i)
-        session.substitutionCount = i * 2
+        session.duration = TimeInterval(600 * sessionNumber)
+        session.substitutionCount = sessionNumber * 2
         sessions.append(session)
     }
 

--- a/SubTimer/Views/Components/Timer/ManualSubstitutionSheetView.swift
+++ b/SubTimer/Views/Components/Timer/ManualSubstitutionSheetView.swift
@@ -56,7 +56,7 @@ struct ManualSubstitutionSheetView: View {
         benchPlayers: [
             Player(name: "Bob", status: .benched, sortOrder: 1),
             Player(name: "Charlie", status: .benched, sortOrder: 2),
-            Player(name: "Diana", status: .benched, sortOrder: 3),
+            Player(name: "Diana", status: .benched, sortOrder: 3)
         ],
         onSubstitute: { player in print("Substituting in: \(player.name)") },
         onCancel: { print("Cancelled") }
@@ -67,7 +67,7 @@ struct ManualSubstitutionSheetView: View {
     ManualSubstitutionSheetView(
         playerToSubOut: Player(name: "Alice", status: .active, sortOrder: 0),
         benchPlayers: [
-            Player(name: "Bob", status: .benched, sortOrder: 1),
+            Player(name: "Bob", status: .benched, sortOrder: 1)
         ],
         onSubstitute: { player in print("Substituting in: \(player.name)") },
         onCancel: { print("Cancelled") }
@@ -80,7 +80,7 @@ struct ManualSubstitutionSheetView: View {
         benchPlayers: [
             Player(name: "Bob", totalPlayTime: 300, status: .benched, sortOrder: 1),
             Player(name: "Charlie", totalPlayTime: 180, status: .benched, sortOrder: 2),
-            Player(name: "Diana", totalPlayTime: 420, status: .benched, sortOrder: 3),
+            Player(name: "Diana", totalPlayTime: 420, status: .benched, sortOrder: 3)
         ],
         onSubstitute: { player in print("Substituting in: \(player.name)") },
         onCancel: { print("Cancelled") }

--- a/SubTimer/Views/TimerView.swift
+++ b/SubTimer/Views/TimerView.swift
@@ -50,22 +50,22 @@
 //
 
 /*
- IDEA:
- - Add a widget that appears on my lock screen showing active session timer
- - Add a dynamic island widget showing the count down
- - Add ability to force the app to stay on (not go to sleep)
+IDEA:
+- Add a widget that appears on my lock screen showing active session timer
+- Add a dynamic island widget showing the count down
+- Add ability to force the app to stay on (not go to sleep)
 
- */
+*/
 
 import ActivityKit
 import SwiftData
 import SwiftUI
 
 private struct TimerVisibilityPreferenceKey: PreferenceKey {
-  static let defaultValue: CGRect = .zero
-  static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
-    value = nextValue()
-  }
+    static let defaultValue: CGRect = .zero
+    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
+        value = nextValue()
+    }
 }
 
 /// The player-related sheet currently presented on `TimerView`, if any.
@@ -76,344 +76,344 @@ private struct TimerVisibilityPreferenceKey: PreferenceKey {
 /// hand-off just a normal state change within one presentation, not a
 /// cross-modifier coordination problem.
 private enum TimerSheet: Identifiable {
-  case playerActions(Player)
-  case manualSubstitution(playerToSubOut: Player)
+    case playerActions(Player)
+    case manualSubstitution(playerToSubOut: Player)
 
-  var id: String {
-    switch self {
-    case .playerActions(let player):
-      "playerActions-\(player.id)"
-    case .manualSubstitution(let player):
-      "manualSubstitution-\(player.id)"
+    var id: String {
+        switch self {
+        case .playerActions(let player):
+            "playerActions-\(player.id)"
+        case .manualSubstitution(let player):
+            "manualSubstitution-\(player.id)"
+        }
     }
-  }
 }
 
 // This view's `body` and its state-management helpers exceed the default
 // 250-line ceiling; extracting further is future work, not this ticket.
 // swiftlint:disable:next type_body_length
 struct TimerView: View {
-  @Environment(\.modelContext) private var modelContext
-  @Query(sort: \Player.sortOrder) var players: [Player]
-  @Query private var configurations: [AppConfiguration]
-  @Query(sort: \Session.startDate, order: .reverse) var sessions: [Session]
-  @Query private var orderManagers: [OrderManager]
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \Player.sortOrder) var players: [Player]
+    @Query private var configurations: [AppConfiguration]
+    @Query(sort: \Session.startDate, order: .reverse) var sessions: [Session]
+    @Query private var orderManagers: [OrderManager]
 
-  @State var timerViewModel: TimerViewModel?
-  @State private var activeSheet: TimerSheet?
-  @State private var benchOrder: [UUID] = []
-  @State private var activeOrder: [UUID] = []
-  @State private var cachedManagers: [PlayerOrderRole: OrderManager] = [:]
-  @State private var showPinnedButton = false
-  @State private var overtimeUpdateWork: DispatchWorkItem?
-  @State private var showCompactTimer = false
+    @State var timerViewModel: TimerViewModel?
+    @State private var activeSheet: TimerSheet?
+    @State private var benchOrder: [UUID] = []
+    @State private var activeOrder: [UUID] = []
+    @State private var cachedManagers: [PlayerOrderRole: OrderManager] = [:]
+    @State private var showPinnedButton = false
+    @State private var overtimeUpdateWork: DispatchWorkItem?
+    @State private var showCompactTimer = false
 
-  var configuration: AppConfiguration {
-    if let config = configurations.first {
-      return config
-    } else {
-      let newConfig = AppConfiguration()
-      modelContext.insert(newConfig)
-      return newConfig
-    }
-  }
-
-  func orderManager(for role: PlayerOrderRole) -> OrderManager {
-    if let cached = cachedManagers[role] {
-      return cached
-    }
-
-    if let manager = orderManagers.first(where: { $0.role == role }) {
-      cachedManagers[role] = manager
-      return manager
-    } else {
-      let newManager = OrderManager(role: role)
-      modelContext.insert(newManager)
-      try? modelContext.save()
-      cachedManagers[role] = newManager
-      return newManager
-    }
-  }
-
-  var benchManager: OrderManager { orderManager(for: .bench) }
-
-  var activeManager: OrderManager { orderManager(for: .active) }
-
-  var activePlayers: [Player] {
-    let active = players.filter { $0.status == .active }
-
-    let orderToUse = activeOrder.isEmpty
-      ? (orderManagers.first(where: { $0.role == .active })?.playerOrder ?? [])
-      : activeOrder
-
-    return active.sorted { player1, player2 in
-      let pos1 = orderToUse.firstIndex(of: player1.id)
-      let pos2 = orderToUse.firstIndex(of: player2.id)
-
-      if let pos1, let pos2 {
-        return pos1 < pos2
-      } else if pos1 != nil {
-        return true
-      } else if pos2 != nil {
-        return false
-      } else {
-        return player1.currentPlayDuration > player2.currentPlayDuration
-      }
-    }
-  }
-
-  var benchedPlayers: [Player] {
-    let benched = players.filter { $0.status == .benched }
-
-    // Use the state-managed bench order for immediate UI updates
-    let orderToUse = benchOrder.isEmpty
-      ? (orderManagers.first(where: { $0.role == .bench })?.playerOrder ?? [])
-      : benchOrder
-
-    // Sort by bench order, then by sortOrder for players not in the bench order
-    return benched.sorted { player1, player2 in
-      let pos1 = orderToUse.firstIndex(of: player1.id)
-      let pos2 = orderToUse.firstIndex(of: player2.id)
-
-      if let pos1, let pos2 {
-        return pos1 < pos2
-      } else if pos1 != nil {
-        return true
-      } else if pos2 != nil {
-        return false
-      } else {
-        return player1.sortOrder < player2.sortOrder
-      }
-    }
-  }
-
-  var temporarilyOutPlayers: [Player] {
-    players.filter { $0.status == .temporarilyOut }
-  }
-
-  var body: some View {
-    NavigationStack {
-      ZStack {
-        if players.isEmpty {
-          emptyStateView
+    var configuration: AppConfiguration {
+        if let config = configurations.first {
+            return config
         } else {
-          mainTimerView
+            let newConfig = AppConfiguration()
+            modelContext.insert(newConfig)
+            return newConfig
         }
-      }
-      .navigationTitle("Super Sub")
-      .onAppear {
-        // Initialize cached managers first
-        _ = benchManager
-        _ = activeManager
-        initializeViewModel(allPlayers: players)
-        syncOrderManager(role: .bench, status: .benched)
-        syncOrderManager(role: .active, status: .active)
-        loadOrder(for: .bench)
-        loadOrder(for: .active)
-      }
-      .sheet(item: $activeSheet) { sheet in
-        switch sheet {
-        case .playerActions(let player):
-          playerActionsSheet(player: player)
-        case .manualSubstitution(let playerToSubOut):
-          manualSubstitutionSheet(playerToSubOut: playerToSubOut)
-        }
-      }
     }
-  }
 
-  // MARK: - Empty State
-
-  private var emptyStateView: some View {
-    ContentUnavailableView(
-      "No Players",
-      systemImage: "person.3.slash",
-      description: Text("Add players in Settings to start tracking substitutions.")
-    )
-  }
-
-  // MARK: - Main Timer View
-
-  private var mainTimerView: some View {
-    ScrollViewReader { scrollProxy in
-      ScrollView {
-        VStack(spacing: 24) {
-          timerControlsSection
-            .id("timerControls")
-          preferredTimeDisplay
-            .background(
-              GeometryReader { geo in
-                Color.clear.preference(
-                  key: TimerVisibilityPreferenceKey.self,
-                  value: geo.frame(in: .named("timerScroll"))
-                )
-              }
-            )
-          activePlayersSection
-          benchSection
-          if !temporarilyOutPlayers.isEmpty {
-            temporarilyOutSection
-          }
+    func orderManager(for role: PlayerOrderRole) -> OrderManager {
+        if let cached = cachedManagers[role] {
+            return cached
         }
-        .padding()
-      }
-      .coordinateSpace(name: "timerScroll")
-      .onPreferenceChange(TimerVisibilityPreferenceKey.self) { frame in
-        let isVisible = frame.maxY > 0
-        if showCompactTimer != !isVisible {
-          withAnimation(.easeInOut(duration: 0.25)) {
-            showCompactTimer = !isVisible
-          }
+
+        if let manager = orderManagers.first(where: { $0.role == role }) {
+            cachedManagers[role] = manager
+            return manager
+        } else {
+            let newManager = OrderManager(role: role)
+            modelContext.insert(newManager)
+            try? modelContext.save()
+            cachedManagers[role] = newManager
+            return newManager
         }
-      }
-      .safeAreaInset(edge: .top) {
-        if showCompactTimer {
-          CompactTimerBarView(
-            currentPlayDuration: timerViewModel?.elapsedTime ?? 0,
-            preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
-            onTap: {
-              withAnimation {
-                scrollProxy.scrollTo("timerControls", anchor: .top)
-              }
+    }
+
+    var benchManager: OrderManager { orderManager(for: .bench) }
+
+    var activeManager: OrderManager { orderManager(for: .active) }
+
+    var activePlayers: [Player] {
+        let active = players.filter { $0.status == .active }
+
+        let orderToUse = activeOrder.isEmpty
+            ? (orderManagers.first(where: { $0.role == .active })?.playerOrder ?? [])
+            : activeOrder
+
+        return active.sorted { player1, player2 in
+            let pos1 = orderToUse.firstIndex(of: player1.id)
+            let pos2 = orderToUse.firstIndex(of: player2.id)
+
+            if let pos1, let pos2 {
+                return pos1 < pos2
+            } else if pos1 != nil {
+                return true
+            } else if pos2 != nil {
+                return false
+            } else {
+                return player1.currentPlayDuration > player2.currentPlayDuration
             }
-          )
-          .transition(.move(edge: .top).combined(with: .opacity))
         }
-      }
-      .safeAreaInset(edge: .bottom) {
-        pinnedSubstituteButton
-          .opacity(showPinnedButton ? 1 : 0)
-          .offset(y: showPinnedButton ? 0 : 40)
-      }
-      .onAppear {
-        guard !showPinnedButton else { return }
-        withAnimation(.easeOut(duration: 0.45).delay(0.15)) {
-          showPinnedButton = true
+    }
+
+    var benchedPlayers: [Player] {
+        let benched = players.filter { $0.status == .benched }
+
+        // Use the state-managed bench order for immediate UI updates
+        let orderToUse = benchOrder.isEmpty
+            ? (orderManagers.first(where: { $0.role == .bench })?.playerOrder ?? [])
+            : benchOrder
+
+        // Sort by bench order, then by sortOrder for players not in the bench order
+        return benched.sorted { player1, player2 in
+            let pos1 = orderToUse.firstIndex(of: player1.id)
+            let pos2 = orderToUse.firstIndex(of: player2.id)
+
+            if let pos1, let pos2 {
+                return pos1 < pos2
+            } else if pos1 != nil {
+                return true
+            } else if pos2 != nil {
+                return false
+            } else {
+                return player1.sortOrder < player2.sortOrder
+            }
         }
-      }
     }
-  }
 
-  // MARK: - Pinned Substitute Button
-
-  private var pinnedSubstituteButton: some View {
-    VStack(spacing: 0) {
-      Divider()
-      substituteButtonSection
-        .padding(.horizontal)
-        .padding(.vertical, 8)
+    var temporarilyOutPlayers: [Player] {
+        players.filter { $0.status == .temporarilyOut }
     }
-    .glassEffect(.regular.interactive(), in: .rect)
-  }
 
-  // MARK: - Timer Controls
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                if players.isEmpty {
+                    emptyStateView
+                } else {
+                    mainTimerView
+                }
+            }
+            .navigationTitle("Super Sub")
+            .onAppear {
+                // Initialize cached managers first
+                _ = benchManager
+                _ = activeManager
+                initializeViewModel(allPlayers: players)
+                syncOrderManager(role: .bench, status: .benched)
+                syncOrderManager(role: .active, status: .active)
+                loadOrder(for: .bench)
+                loadOrder(for: .active)
+            }
+            .sheet(item: $activeSheet) { sheet in
+                switch sheet {
+                case .playerActions(let player):
+                    playerActionsSheet(player: player)
+                case .manualSubstitution(let playerToSubOut):
+                    manualSubstitutionSheet(playerToSubOut: playerToSubOut)
+                }
+            }
+        }
+    }
 
-  private var timerControlsSection: some View {
-    TimerControlsView(
-      isRunning: timerViewModel?.isRunning ?? false,
-      onToggle: toggleTimer,
-      onReset: resetTimer
-    )
-  }
+    // MARK: - Empty State
 
-  // MARK: - Preferred Time Display
+    private var emptyStateView: some View {
+        ContentUnavailableView(
+            "No Players",
+            systemImage: "person.3.slash",
+            description: Text("Add players in Settings to start tracking substitutions.")
+        )
+    }
 
-  private var preferredTimeDisplay: some View {
-    let currentDuration = timerViewModel?.elapsedTime ?? 0
+    // MARK: - Main Timer View
 
-    return PreferredTimeDisplayView(
-      currentPlayDuration: currentDuration,
-      preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds
-    )
-  }
+    private var mainTimerView: some View {
+        ScrollViewReader { scrollProxy in
+            ScrollView {
+                VStack(spacing: 24) {
+                    timerControlsSection
+                        .id("timerControls")
+                    preferredTimeDisplay
+                        .background(
+                            GeometryReader { geo in
+                                Color.clear.preference(
+                                    key: TimerVisibilityPreferenceKey.self,
+                                    value: geo.frame(in: .named("timerScroll"))
+                                )
+                            }
+                        )
+                    activePlayersSection
+                    benchSection
+                    if !temporarilyOutPlayers.isEmpty {
+                        temporarilyOutSection
+                    }
+                }
+                .padding()
+            }
+            .coordinateSpace(name: "timerScroll")
+            .onPreferenceChange(TimerVisibilityPreferenceKey.self) { frame in
+                let isVisible = frame.maxY > 0
+                if showCompactTimer != !isVisible {
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        showCompactTimer = !isVisible
+                    }
+                }
+            }
+            .safeAreaInset(edge: .top) {
+                if showCompactTimer {
+                    CompactTimerBarView(
+                        currentPlayDuration: timerViewModel?.elapsedTime ?? 0,
+                        preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
+                        onTap: {
+                            withAnimation {
+                                scrollProxy.scrollTo("timerControls", anchor: .top)
+                            }
+                        }
+                    )
+                    .transition(.move(edge: .top).combined(with: .opacity))
+                }
+            }
+            .safeAreaInset(edge: .bottom) {
+                pinnedSubstituteButton
+                    .opacity(showPinnedButton ? 1 : 0)
+                    .offset(y: showPinnedButton ? 0 : 40)
+            }
+            .onAppear {
+                guard !showPinnedButton else { return }
+                withAnimation(.easeOut(duration: 0.45).delay(0.15)) {
+                    showPinnedButton = true
+                }
+            }
+        }
+    }
 
-  // MARK: - Active Players Section
+    // MARK: - Pinned Substitute Button
 
-  private var activePlayersSection: some View {
-    ActivePlayersSectionView(
-      players: activePlayers,
-      maxActiveCount: configuration.activePlayersCount,
-      onPlayerTap: { player in activeSheet = .playerActions(player) },
-      onReorder: { self.reorderPlayers($0, role: .active) }
-    )
-  }
+    private var pinnedSubstituteButton: some View {
+        VStack(spacing: 0) {
+            Divider()
+            substituteButtonSection
+                .padding(.horizontal)
+                .padding(.vertical, 8)
+        }
+        .glassEffect(.regular.interactive(), in: .rect)
+    }
 
-  // MARK: - Bench Section
+    // MARK: - Timer Controls
 
-  private var benchSection: some View {
-    BenchSectionView(
-      players: benchedPlayers,
-      activePlayersCount: activePlayers.count,
-      maxActiveCount: configuration.activePlayersCount,
-      onPlayerTap: { player in activeSheet = .playerActions(player) },
-      onActivatePlayer: activatePlayer,
-      onReorder: { self.reorderPlayers($0, role: .bench) }
-    )
-  }
+    private var timerControlsSection: some View {
+        TimerControlsView(
+            isRunning: timerViewModel?.isRunning ?? false,
+            onToggle: toggleTimer,
+            onReset: resetTimer
+        )
+    }
 
-  // MARK: - Temporarily Out Section
+    // MARK: - Preferred Time Display
 
-  private var temporarilyOutSection: some View {
-    TemporarilyOutSectionView(
-      players: temporarilyOutPlayers,
-      onReturnToBench: returnPlayerToBench
-    )
-  }
+    private var preferredTimeDisplay: some View {
+        let currentDuration = timerViewModel?.elapsedTime ?? 0
 
-  // MARK: - Substitute Button
+        return PreferredTimeDisplayView(
+            currentPlayDuration: currentDuration,
+            preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds
+        )
+    }
 
-  private var substituteButtonSection: some View {
-    SubstitutionButtonView(
-      canPerformSubstitution: canPerformSubstitution,
-      onSubstitute: performAutomaticSubstitution
-    )
-  }
+    // MARK: - Active Players Section
 
-  private var canPerformSubstitution: Bool {
-    !activePlayers.isEmpty && !benchedPlayers.isEmpty
-  }
+    private var activePlayersSection: some View {
+        ActivePlayersSectionView(
+            players: activePlayers,
+            maxActiveCount: configuration.activePlayersCount,
+            onPlayerTap: { player in activeSheet = .playerActions(player) },
+            onReorder: { self.reorderPlayers($0, role: .active) }
+        )
+    }
 
-  // MARK: - Manual Substitution Sheet
+    // MARK: - Bench Section
 
-  private func manualSubstitutionSheet(playerToSubOut: Player) -> some View {
-    ManualSubstitutionSheetView(
-      playerToSubOut: playerToSubOut,
-      benchPlayers: benchedPlayers,
-      onSubstitute: { benchPlayer in
-        performManualSubstitution(subOut: playerToSubOut, subIn: benchPlayer)
-      },
-      onCancel: {
-        activeSheet = nil
-      }
-    )
-  }
+    private var benchSection: some View {
+        BenchSectionView(
+            players: benchedPlayers,
+            activePlayersCount: activePlayers.count,
+            maxActiveCount: configuration.activePlayersCount,
+            onPlayerTap: { player in activeSheet = .playerActions(player) },
+            onActivatePlayer: activatePlayer,
+            onReorder: { self.reorderPlayers($0, role: .bench) }
+        )
+    }
 
-  // MARK: - Player Actions Sheet
+    // MARK: - Temporarily Out Section
 
-  private func playerActionsSheet(player: Player) -> some View {
-    PlayerActionsSheetView(
-      player: player,
-      canActivate: activePlayers.count < configuration.activePlayersCount,
-      onSubstituteOut: {
-        activeSheet = .manualSubstitution(playerToSubOut: player)
-      },
-      onActivatePlayer: {
-        activatePlayer(player)
-        activeSheet = nil
-      },
-      onMarkTemporarilyOut: {
-        markPlayerTemporarilyOut(player)
-        activeSheet = nil
-      },
-      onReturnToBench: {
-        returnPlayerToBench(player)
-        activeSheet = nil
-      },
-      onClose: {
-        activeSheet = nil
-      }
-    )
-  }
+    private var temporarilyOutSection: some View {
+        TemporarilyOutSectionView(
+            players: temporarilyOutPlayers,
+            onReturnToBench: returnPlayerToBench
+        )
+    }
+
+    // MARK: - Substitute Button
+
+    private var substituteButtonSection: some View {
+        SubstitutionButtonView(
+            canPerformSubstitution: canPerformSubstitution,
+            onSubstitute: performAutomaticSubstitution
+        )
+    }
+
+    private var canPerformSubstitution: Bool {
+        !activePlayers.isEmpty && !benchedPlayers.isEmpty
+    }
+
+    // MARK: - Manual Substitution Sheet
+
+    private func manualSubstitutionSheet(playerToSubOut: Player) -> some View {
+        ManualSubstitutionSheetView(
+            playerToSubOut: playerToSubOut,
+            benchPlayers: benchedPlayers,
+            onSubstitute: { benchPlayer in
+                performManualSubstitution(subOut: playerToSubOut, subIn: benchPlayer)
+            },
+            onCancel: {
+                activeSheet = nil
+            }
+        )
+    }
+
+    // MARK: - Player Actions Sheet
+
+    private func playerActionsSheet(player: Player) -> some View {
+        PlayerActionsSheetView(
+            player: player,
+            canActivate: activePlayers.count < configuration.activePlayersCount,
+            onSubstituteOut: {
+                activeSheet = .manualSubstitution(playerToSubOut: player)
+            },
+            onActivatePlayer: {
+                activatePlayer(player)
+                activeSheet = nil
+            },
+            onMarkTemporarilyOut: {
+                markPlayerTemporarilyOut(player)
+                activeSheet = nil
+            },
+            onReturnToBench: {
+                returnPlayerToBench(player)
+                activeSheet = nil
+            },
+            onClose: {
+                activeSheet = nil
+            }
+        )
+    }
 }
 
 // MARK: - Business Logic Extension
@@ -421,348 +421,348 @@ struct TimerView: View {
 /// Extension containing all business logic and action handlers
 /// Separated for clarity while maintaining access to private properties
 extension TimerView {
-  // MARK: - Timer Management
+    // MARK: - Timer Management
 
-  func initializeViewModel(allPlayers: [Player]) {
-    if timerViewModel == nil {
-      timerViewModel = TimerViewModel(players: allPlayers)
-    }
-    timerViewModel?.onTimerTick = { updatePlayerTimes() }
-  }
-
-  /// Syncs a role-scoped order (players is already `@Query(sort: \Player.sortOrder)`,
-  /// so filtering it preserves roster order) against current player statuses: adds
-  /// players missing from the order, drops ones that changed status.
-  func syncOrderManager(role: PlayerOrderRole, status: PlayerStatus) {
-    let manager = orderManager(for: role)
-    let currentPlayers = players.filter { $0.status == status }
-
-    for player in currentPlayers where manager.position(of: player.id) == nil {
-      manager.addPlayer(player.id)
+    func initializeViewModel(allPlayers: [Player]) {
+        if timerViewModel == nil {
+            timerViewModel = TimerViewModel(players: allPlayers)
+        }
+        timerViewModel?.onTimerTick = { updatePlayerTimes() }
     }
 
-    let currentIds = Set(currentPlayers.map { $0.id })
-    manager.playerOrder.removeAll { !currentIds.contains($0) }
-    manager.updatedDate = Date()
-  }
+    /// Syncs a role-scoped order (players is already `@Query(sort: \Player.sortOrder)`,
+    /// so filtering it preserves roster order) against current player statuses: adds
+    /// players missing from the order, drops ones that changed status.
+    func syncOrderManager(role: PlayerOrderRole, status: PlayerStatus) {
+        let manager = orderManager(for: role)
+        let currentPlayers = players.filter { $0.status == status }
 
-  func loadOrder(for role: PlayerOrderRole) {
-    switch role {
-    case .bench:
-      benchOrder = orderManager(for: role).playerOrder
-    case .active:
-      activeOrder = orderManager(for: role).playerOrder
-    }
-  }
+        for player in currentPlayers where manager.position(of: player.id) == nil {
+            manager.addPlayer(player.id)
+        }
 
-  func reorderPlayers(_ reorderedPlayers: [Player], role: PlayerOrderRole) {
-    let newOrder = reorderedPlayers.map { $0.id }
-
-    switch role {
-    case .bench:
-      benchOrder = newOrder
-    case .active:
-      activeOrder = newOrder
+        let currentIds = Set(currentPlayers.map { $0.id })
+        manager.playerOrder.removeAll { !currentIds.contains($0) }
+        manager.updatedDate = Date()
     }
 
-    let manager = orderManager(for: role)
-    manager.playerOrder.removeAll()
-    manager.playerOrder.append(contentsOf: newOrder)
-    manager.updatedDate = Date()
-  }
-
-  func toggleTimer() {
-    guard let viewModel = timerViewModel else { return }
-    if viewModel.isRunning {
-      viewModel.pauseTimer()
-      cancelOvertimeUpdate()
-      updateLiveActivity()
-    } else {
-      autoActivateInitialPlayersIfNeeded()
-      createOrUpdateSession()
-      viewModel.startTimer()
-      startLiveActivity()
-    }
-  }
-
-  func resetTimer() {
-    guard let viewModel = timerViewModel else { return }
-    viewModel.resetTimer()
-    endLiveActivity()
-  }
-
-  private func autoActivateInitialPlayersIfNeeded() {
-    guard activePlayers.isEmpty else { return }
-    let allFilteredPlayers = activePlayers + benchedPlayers + temporarilyOutPlayers
-    let playersToActivate = min(configuration.activePlayersCount, allFilteredPlayers.count)
-    let now = Date()
-    for index in 0..<playersToActivate where index < allFilteredPlayers.count {
-      allFilteredPlayers[index].status = .active
-      allFilteredPlayers[index].activatedAtDate = now
-      allFilteredPlayers[index].currentPlayDuration = 0
-      activeManager.addPlayer(allFilteredPlayers[index].id)
-    }
-    activeOrder = activeManager.playerOrder
-  }
-
-  private func updatePlayerTimes() {
-    let now = Date()
-
-    for player in activePlayers {
-      player.currentPlayDuration = now.timeIntervalSince(player.activatedAtDate)
+    func loadOrder(for role: PlayerOrderRole) {
+        switch role {
+        case .bench:
+            benchOrder = orderManager(for: role).playerOrder
+        case .active:
+            activeOrder = orderManager(for: role).playerOrder
+        }
     }
 
-    if let activeSession = sessions.first(where: { $0.isActive }) {
-      activeSession.duration = now.timeIntervalSince(activeSession.startDate)
-    }
-    checkPreferredTimeAlert()
-  }
+    func reorderPlayers(_ reorderedPlayers: [Player], role: PlayerOrderRole) {
+        let newOrder = reorderedPlayers.map { $0.id }
 
-  private func checkPreferredTimeAlert() {
-    guard let timerElapsed = timerViewModel?.elapsedTime else { return }
-    let preferredTime = TimeInterval(configuration.preferredPlayTimeSeconds)
-    if preferredTime > 0, timerElapsed == preferredTime {
-      triggerPreferredTimeAlert()
-    }
-  }
+        switch role {
+        case .bench:
+            benchOrder = newOrder
+        case .active:
+            activeOrder = newOrder
+        }
 
-  // MARK: - Substitution
-
-  func performAutomaticSubstitution() {
-    guard
-      let playerToSubOut = activePlayers.first,
-      let playerToSubIn = benchedPlayers.first
-    else { return }
-    performSubstitution(subOut: playerToSubOut, subIn: playerToSubIn)
-  }
-
-  func performManualSubstitution(subOut: Player, subIn: Player) {
-    performSubstitution(subOut: subOut, subIn: subIn)
-    activeSheet = nil
-  }
-
-  private func performSubstitution(subOut: Player, subIn: Player) {
-    let now = Date()
-    let wasRunning = timerViewModel?.isRunning ?? false
-
-    if wasRunning {
-      timerViewModel?.pauseTimer()
+        let manager = orderManager(for: role)
+        manager.playerOrder.removeAll()
+        manager.playerOrder.append(contentsOf: newOrder)
+        manager.updatedDate = Date()
     }
 
-    let timePlayedThisSegment = now.timeIntervalSince(subOut.activatedAtDate)
-    subOut.totalPlayTime += timePlayedThisSegment
-    subOut.status = .benched
-    subOut.currentPlayDuration = 0
-
-    subIn.status = .active
-    subIn.activatedAtDate = now
-    subIn.currentPlayDuration = 0
-
-    benchManager.removePlayer(subIn.id)
-    benchManager.addPlayer(subOut.id)
-    benchOrder = benchManager.playerOrder
-
-    activeManager.removePlayer(subOut.id)
-    activeManager.addPlayer(subIn.id)
-    activeOrder = activeManager.playerOrder
-
-    if let activeSession = sessions.first(where: { $0.isActive }) {
-      activeSession.substitutionCount += 1
+    func toggleTimer() {
+        guard let viewModel = timerViewModel else { return }
+        if viewModel.isRunning {
+            viewModel.pauseTimer()
+            cancelOvertimeUpdate()
+            updateLiveActivity()
+        } else {
+            autoActivateInitialPlayersIfNeeded()
+            createOrUpdateSession()
+            viewModel.startTimer()
+            startLiveActivity()
+        }
     }
 
-    timerViewModel?.resetTimer()
-
-    if wasRunning {
-      timerViewModel?.startTimer()
+    func resetTimer() {
+        guard let viewModel = timerViewModel else { return }
+        viewModel.resetTimer()
+        endLiveActivity()
     }
 
-    provideHapticFeedback()
-    updateLiveActivity()
-    if wasRunning {
-      scheduleOvertimeUpdate()
+    private func autoActivateInitialPlayersIfNeeded() {
+        guard activePlayers.isEmpty else { return }
+        let allFilteredPlayers = activePlayers + benchedPlayers + temporarilyOutPlayers
+        let playersToActivate = min(configuration.activePlayersCount, allFilteredPlayers.count)
+        let now = Date()
+        for index in 0..<playersToActivate where index < allFilteredPlayers.count {
+            allFilteredPlayers[index].status = .active
+            allFilteredPlayers[index].activatedAtDate = now
+            allFilteredPlayers[index].currentPlayDuration = 0
+            activeManager.addPlayer(allFilteredPlayers[index].id)
+        }
+        activeOrder = activeManager.playerOrder
     }
-  }  // MARK: - Player Status
 
-  func activatePlayer(_ player: Player) {
-    player.status = .active
-    player.activatedAtDate = Date()
-    player.currentPlayDuration = 0
-    benchManager.removePlayer(player.id)
-    benchOrder = benchManager.playerOrder
-    activeManager.addPlayer(player.id)
-    activeOrder = activeManager.playerOrder
-    updateLiveActivity()
-  }
+    private func updatePlayerTimes() {
+        let now = Date()
 
-  func markPlayerTemporarilyOut(_ player: Player) {
-    if player.status == .active {
-      let timePlayedThisSegment = Date().timeIntervalSince(player.activatedAtDate)
-      player.totalPlayTime += timePlayedThisSegment
-      activeManager.removePlayer(player.id)
-      activeOrder = activeManager.playerOrder
+        for player in activePlayers {
+            player.currentPlayDuration = now.timeIntervalSince(player.activatedAtDate)
+        }
+
+        if let activeSession = sessions.first(where: { $0.isActive }) {
+            activeSession.duration = now.timeIntervalSince(activeSession.startDate)
+        }
+        checkPreferredTimeAlert()
     }
-    player.status = .temporarilyOut
-    updateLiveActivity()
-  }
 
-  func returnPlayerToBench(_ player: Player) {
-    player.status = .benched
-    benchManager.addPlayer(player.id)
-    benchOrder = benchManager.playerOrder
-    updateLiveActivity()
-  }
-
-  // MARK: - Session & Feedback
-
-  private func createOrUpdateSession() {
-    guard !sessions.contains(where: { $0.isActive }) else { return }
-    let allPlayerNames = (activePlayers + benchedPlayers + temporarilyOutPlayers).map { $0.name }
-    let newSession = Session(
-      preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
-      activePlayersCount: configuration.activePlayersCount,
-      playerNames: allPlayerNames
-    )
-    modelContext.insert(newSession)
-  }
-
-  private func triggerPreferredTimeAlert() {
-    UINotificationFeedbackGenerator().notificationOccurred(.warning)
-  }
-
-  private func provideHapticFeedback() {
-    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-  }
-
-  // MARK: - Live Activity Management
-
-  private func startLiveActivity() {
-    if #available(iOS 16.2, *) {
-      let sessionName: String
-      if let activeSession = sessions.first(where: { $0.isActive }) {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMM d, h:mm a"
-        sessionName = formatter.string(from: activeSession.startDate)
-      } else {
-        sessionName = "Practice Session"
-      }
-
-      LiveActivityManager.shared.startActivity(
-        sessionName: sessionName,
-        isRunning: timerViewModel?.isRunning ?? false,
-        timerStartDate: timerViewModel?.timerStartDate ?? Date(),
-        accumulatedTime: timerViewModel?.accumulatedTime ?? 0,
-        preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
-        activePlayersCount: activePlayers.count,
-        benchedPlayersCount: benchedPlayers.count,
-        subOutPlayerName: activePlayers.first?.name,
-        subInPlayerName: benchedPlayers.first?.name
-      )
-      scheduleOvertimeUpdate()
+    private func checkPreferredTimeAlert() {
+        guard let timerElapsed = timerViewModel?.elapsedTime else { return }
+        let preferredTime = TimeInterval(configuration.preferredPlayTimeSeconds)
+        if preferredTime > 0, timerElapsed == preferredTime {
+            triggerPreferredTimeAlert()
+        }
     }
-  }
 
-  private func updateLiveActivity() {
-    if #available(iOS 16.2, *) {
-      LiveActivityManager.shared.updateActivity(
-        isRunning: timerViewModel?.isRunning ?? false,
-        timerStartDate: timerViewModel?.timerStartDate ?? Date(),
-        accumulatedTime: timerViewModel?.accumulatedTime ?? 0,
-        preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
-        activePlayersCount: activePlayers.count,
-        benchedPlayersCount: benchedPlayers.count,
-        subOutPlayerName: activePlayers.first?.name,
-        subInPlayerName: benchedPlayers.first?.name
-      )
+    // MARK: - Substitution
+
+    func performAutomaticSubstitution() {
+        guard
+            let playerToSubOut = activePlayers.first,
+            let playerToSubIn = benchedPlayers.first
+        else { return }
+        performSubstitution(subOut: playerToSubOut, subIn: playerToSubIn)
     }
-  }
 
-  private func endLiveActivity() {
-    if #available(iOS 16.2, *) {
-      cancelOvertimeUpdate()
-      LiveActivityManager.shared.endActivity()
+    func performManualSubstitution(subOut: Player, subIn: Player) {
+        performSubstitution(subOut: subOut, subIn: subIn)
+        activeSheet = nil
     }
-  }
 
-  private func scheduleOvertimeUpdate() {
-    cancelOvertimeUpdate()
+    private func performSubstitution(subOut: Player, subIn: Player) {
+        let now = Date()
+        let wasRunning = timerViewModel?.isRunning ?? false
 
-    let preferredSeconds = configuration.preferredPlayTimeSeconds
-    guard preferredSeconds > 0 else { return }
+        if wasRunning {
+            timerViewModel?.pauseTimer()
+        }
 
-    let accumulated = timerViewModel?.accumulatedTime ?? 0
-    let delay = TimeInterval(preferredSeconds) - accumulated
-    guard delay > 0 else { return }
+        let timePlayedThisSegment = now.timeIntervalSince(subOut.activatedAtDate)
+        subOut.totalPlayTime += timePlayedThisSegment
+        subOut.status = .benched
+        subOut.currentPlayDuration = 0
 
-    let work = DispatchWorkItem { [self] in
-      updateLiveActivity()
+        subIn.status = .active
+        subIn.activatedAtDate = now
+        subIn.currentPlayDuration = 0
+
+        benchManager.removePlayer(subIn.id)
+        benchManager.addPlayer(subOut.id)
+        benchOrder = benchManager.playerOrder
+
+        activeManager.removePlayer(subOut.id)
+        activeManager.addPlayer(subIn.id)
+        activeOrder = activeManager.playerOrder
+
+        if let activeSession = sessions.first(where: { $0.isActive }) {
+            activeSession.substitutionCount += 1
+        }
+
+        timerViewModel?.resetTimer()
+
+        if wasRunning {
+            timerViewModel?.startTimer()
+        }
+
+        provideHapticFeedback()
+        updateLiveActivity()
+        if wasRunning {
+            scheduleOvertimeUpdate()
+        }
+    }  // MARK: - Player Status
+
+    func activatePlayer(_ player: Player) {
+        player.status = .active
+        player.activatedAtDate = Date()
+        player.currentPlayDuration = 0
+        benchManager.removePlayer(player.id)
+        benchOrder = benchManager.playerOrder
+        activeManager.addPlayer(player.id)
+        activeOrder = activeManager.playerOrder
+        updateLiveActivity()
     }
-    overtimeUpdateWork = work
-    DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
-  }
 
-  private func cancelOvertimeUpdate() {
-    overtimeUpdateWork?.cancel()
-    overtimeUpdateWork = nil
-  }
+    func markPlayerTemporarilyOut(_ player: Player) {
+        if player.status == .active {
+            let timePlayedThisSegment = Date().timeIntervalSince(player.activatedAtDate)
+            player.totalPlayTime += timePlayedThisSegment
+            activeManager.removePlayer(player.id)
+            activeOrder = activeManager.playerOrder
+        }
+        player.status = .temporarilyOut
+        updateLiveActivity()
+    }
+
+    func returnPlayerToBench(_ player: Player) {
+        player.status = .benched
+        benchManager.addPlayer(player.id)
+        benchOrder = benchManager.playerOrder
+        updateLiveActivity()
+    }
+
+    // MARK: - Session & Feedback
+
+    private func createOrUpdateSession() {
+        guard !sessions.contains(where: { $0.isActive }) else { return }
+        let allPlayerNames = (activePlayers + benchedPlayers + temporarilyOutPlayers).map { $0.name }
+        let newSession = Session(
+            preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
+            activePlayersCount: configuration.activePlayersCount,
+            playerNames: allPlayerNames
+        )
+        modelContext.insert(newSession)
+    }
+
+    private func triggerPreferredTimeAlert() {
+        UINotificationFeedbackGenerator().notificationOccurred(.warning)
+    }
+
+    private func provideHapticFeedback() {
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+    }
+
+    // MARK: - Live Activity Management
+
+    private func startLiveActivity() {
+        if #available(iOS 16.2, *) {
+            let sessionName: String
+            if let activeSession = sessions.first(where: { $0.isActive }) {
+                let formatter = DateFormatter()
+                formatter.dateFormat = "MMM d, h:mm a"
+                sessionName = formatter.string(from: activeSession.startDate)
+            } else {
+                sessionName = "Practice Session"
+            }
+
+            LiveActivityManager.shared.startActivity(
+                sessionName: sessionName,
+                isRunning: timerViewModel?.isRunning ?? false,
+                timerStartDate: timerViewModel?.timerStartDate ?? Date(),
+                accumulatedTime: timerViewModel?.accumulatedTime ?? 0,
+                preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
+                activePlayersCount: activePlayers.count,
+                benchedPlayersCount: benchedPlayers.count,
+                subOutPlayerName: activePlayers.first?.name,
+                subInPlayerName: benchedPlayers.first?.name
+            )
+            scheduleOvertimeUpdate()
+        }
+    }
+
+    private func updateLiveActivity() {
+        if #available(iOS 16.2, *) {
+            LiveActivityManager.shared.updateActivity(
+                isRunning: timerViewModel?.isRunning ?? false,
+                timerStartDate: timerViewModel?.timerStartDate ?? Date(),
+                accumulatedTime: timerViewModel?.accumulatedTime ?? 0,
+                preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
+                activePlayersCount: activePlayers.count,
+                benchedPlayersCount: benchedPlayers.count,
+                subOutPlayerName: activePlayers.first?.name,
+                subInPlayerName: benchedPlayers.first?.name
+            )
+        }
+    }
+
+    private func endLiveActivity() {
+        if #available(iOS 16.2, *) {
+            cancelOvertimeUpdate()
+            LiveActivityManager.shared.endActivity()
+        }
+    }
+
+    private func scheduleOvertimeUpdate() {
+        cancelOvertimeUpdate()
+
+        let preferredSeconds = configuration.preferredPlayTimeSeconds
+        guard preferredSeconds > 0 else { return }
+
+        let accumulated = timerViewModel?.accumulatedTime ?? 0
+        let delay = TimeInterval(preferredSeconds) - accumulated
+        guard delay > 0 else { return }
+
+        let work = DispatchWorkItem { [self] in
+            updateLiveActivity()
+        }
+        overtimeUpdateWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+    }
+
+    private func cancelOvertimeUpdate() {
+        overtimeUpdateWork?.cancel()
+        overtimeUpdateWork = nil
+    }
 }
 
 #Preview("Empty State") {
-  TimerView()
-    .modelContainer(for: [Player.self, AppConfiguration.self, Session.self], inMemory: true)
+    TimerView()
+        .modelContainer(for: [Player.self, AppConfiguration.self, Session.self], inMemory: true)
 }
 
 #Preview("Main Timer View") {
-  // Preview providers are compile-time-only and never execute in a shipped
-  // build; the throwing `#Preview` macro overload requires a `@ViewBuilder`
-  // closure, which disallows the explicit `return` below, so `try!` (not
-  // `try?`/do-catch) is the only option that keeps this preview's original
-  // structure intact.
-  // swiftlint:disable:next force_try
-  let container = try! ModelContainer(
-    for: Player.self, AppConfiguration.self, Session.self,
-    configurations: ModelConfiguration(isStoredInMemoryOnly: true)
-  )
+    // Preview providers are compile-time-only and never execute in a shipped
+    // build; the throwing `#Preview` macro overload requires a `@ViewBuilder`
+    // closure, which disallows the explicit `return` below, so `try!` (not
+    // `try?`/do-catch) is the only option that keeps this preview's original
+    // structure intact.
+    // swiftlint:disable:next force_try
+    let container = try! ModelContainer(
+        for: Player.self, AppConfiguration.self, Session.self,
+        configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+    )
 
-  let context = container.mainContext
+    let context = container.mainContext
 
-  // Create configuration
-  let config = AppConfiguration()
-  config.activePlayersCount = 3
-  config.preferredPlayTimeSeconds = 180
-  context.insert(config)
+    // Create configuration
+    let config = AppConfiguration()
+    config.activePlayersCount = 3
+    config.preferredPlayTimeSeconds = 180
+    context.insert(config)
 
-  // Create sample players
-  let player1 = Player(name: "Alice", sortOrder: 0)
-  player1.status = .active
-  player1.currentPlayDuration = 120
+    // Create sample players
+    let player1 = Player(name: "Alice", sortOrder: 0)
+    player1.status = .active
+    player1.currentPlayDuration = 120
 
-  let player2 = Player(name: "Bob", sortOrder: 1)
-  player2.status = .active
-  player2.currentPlayDuration = 95
+    let player2 = Player(name: "Bob", sortOrder: 1)
+    player2.status = .active
+    player2.currentPlayDuration = 95
 
-  let player3 = Player(name: "Charlie", sortOrder: 2)
-  player3.status = .active
-  player3.currentPlayDuration = 110
+    let player3 = Player(name: "Charlie", sortOrder: 2)
+    player3.status = .active
+    player3.currentPlayDuration = 110
 
-  let player4 = Player(name: "Diana", sortOrder: 3)
-  player4.status = .benched
-  player4.totalPlayTime = 85
+    let player4 = Player(name: "Diana", sortOrder: 3)
+    player4.status = .benched
+    player4.totalPlayTime = 85
 
-  let player5 = Player(name: "Eve", sortOrder: 4)
-  player5.status = .benched
-  player5.totalPlayTime = 60
+    let player5 = Player(name: "Eve", sortOrder: 4)
+    player5.status = .benched
+    player5.totalPlayTime = 60
 
-  let player6 = Player(name: "Frank", sortOrder: 5)
-  player6.status = .temporarilyOut
-  player6.totalPlayTime = 75
+    let player6 = Player(name: "Frank", sortOrder: 5)
+    player6.status = .temporarilyOut
+    player6.totalPlayTime = 75
 
-  context.insert(player1)
-  context.insert(player2)
-  context.insert(player3)
-  context.insert(player4)
-  context.insert(player5)
-  context.insert(player6)
+    context.insert(player1)
+    context.insert(player2)
+    context.insert(player3)
+    context.insert(player4)
+    context.insert(player5)
+    context.insert(player6)
 
-  return TimerView()
-    .modelContainer(container)
+    return TimerView()
+        .modelContainer(container)
 }

--- a/SubTimer/Views/TimerView.swift
+++ b/SubTimer/Views/TimerView.swift
@@ -12,6 +12,11 @@
 //  • UI Presentation (lines 1-234): SwiftUI view hierarchy
 //  • Business Logic Extension (lines 235-368): All action handlers
 //
+// This screen coordinates 11 extracted subviews plus their SwiftData/Live
+// Activity wiring, which pushes the file past SwiftLint's default 400-line
+// ceiling; splitting it further is a candidate for a future pass, not this
+// lint-baseline ticket.
+// swiftlint:disable file_length
 //  11 EXTRACTED COMPONENTS:
 //
 //  Timer Components (5):
@@ -84,6 +89,9 @@ private enum TimerSheet: Identifiable {
   }
 }
 
+// This view's `body` and its state-management helpers exceed the default
+// 250-line ceiling; extracting further is future work, not this ticket.
+// swiftlint:disable:next type_body_length
 struct TimerView: View {
   @Environment(\.modelContext) private var modelContext
   @Query(sort: \Player.sortOrder) var players: [Player]
@@ -142,8 +150,8 @@ struct TimerView: View {
       let pos1 = orderToUse.firstIndex(of: player1.id)
       let pos2 = orderToUse.firstIndex(of: player2.id)
 
-      if let p1 = pos1, let p2 = pos2 {
-        return p1 < p2
+      if let pos1, let pos2 {
+        return pos1 < pos2
       } else if pos1 != nil {
         return true
       } else if pos2 != nil {
@@ -167,8 +175,8 @@ struct TimerView: View {
       let pos1 = orderToUse.firstIndex(of: player1.id)
       let pos2 = orderToUse.firstIndex(of: player2.id)
 
-      if let p1 = pos1, let p2 = pos2 {
-        return p1 < p2
+      if let pos1, let pos2 {
+        return pos1 < pos2
       } else if pos1 != nil {
         return true
       } else if pos2 != nil {
@@ -232,7 +240,7 @@ struct TimerView: View {
         VStack(spacing: 24) {
           timerControlsSection
             .id("timerControls")
-          preferredTimeDisplay            
+          preferredTimeDisplay
             .background(
               GeometryReader { geo in
                 Color.clear.preference(
@@ -429,10 +437,8 @@ extension TimerView {
     let manager = orderManager(for: role)
     let currentPlayers = players.filter { $0.status == status }
 
-    for player in currentPlayers {
-      if manager.position(of: player.id) == nil {
-        manager.addPlayer(player.id)
-      }
+    for player in currentPlayers where manager.position(of: player.id) == nil {
+      manager.addPlayer(player.id)
     }
 
     let currentIds = Set(currentPlayers.map { $0.id })
@@ -466,22 +472,22 @@ extension TimerView {
   }
 
   func toggleTimer() {
-    guard let vm = timerViewModel else { return }
-    if vm.isRunning {
-      vm.pauseTimer()
+    guard let viewModel = timerViewModel else { return }
+    if viewModel.isRunning {
+      viewModel.pauseTimer()
       cancelOvertimeUpdate()
       updateLiveActivity()
     } else {
       autoActivateInitialPlayersIfNeeded()
       createOrUpdateSession()
-      vm.startTimer()
+      viewModel.startTimer()
       startLiveActivity()
     }
   }
 
   func resetTimer() {
-    guard let vm = timerViewModel else { return }
-    vm.resetTimer()
+    guard let viewModel = timerViewModel else { return }
+    viewModel.resetTimer()
     endLiveActivity()
   }
 
@@ -490,11 +496,11 @@ extension TimerView {
     let allFilteredPlayers = activePlayers + benchedPlayers + temporarilyOutPlayers
     let playersToActivate = min(configuration.activePlayersCount, allFilteredPlayers.count)
     let now = Date()
-    for i in 0..<playersToActivate where i < allFilteredPlayers.count {
-      allFilteredPlayers[i].status = .active
-      allFilteredPlayers[i].activatedAtDate = now
-      allFilteredPlayers[i].currentPlayDuration = 0
-      activeManager.addPlayer(allFilteredPlayers[i].id)
+    for index in 0..<playersToActivate where index < allFilteredPlayers.count {
+      allFilteredPlayers[index].status = .active
+      allFilteredPlayers[index].activatedAtDate = now
+      allFilteredPlayers[index].currentPlayDuration = 0
+      activeManager.addPlayer(allFilteredPlayers[index].id)
     }
     activeOrder = activeManager.playerOrder
   }
@@ -609,7 +615,7 @@ extension TimerView {
   // MARK: - Session & Feedback
 
   private func createOrUpdateSession() {
-    guard sessions.first(where: { $0.isActive }) == nil else { return }
+    guard !sessions.contains(where: { $0.isActive }) else { return }
     let allPlayerNames = (activePlayers + benchedPlayers + temporarilyOutPlayers).map { $0.name }
     let newSession = Session(
       preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
@@ -706,6 +712,12 @@ extension TimerView {
 }
 
 #Preview("Main Timer View") {
+  // Preview providers are compile-time-only and never execute in a shipped
+  // build; the throwing `#Preview` macro overload requires a `@ViewBuilder`
+  // closure, which disallows the explicit `return` below, so `try!` (not
+  // `try?`/do-catch) is the only option that keeps this preview's original
+  // structure intact.
+  // swiftlint:disable:next force_try
   let container = try! ModelContainer(
     for: Player.self, AppConfiguration.self, Session.self,
     configurations: ModelConfiguration(isStoredInMemoryOnly: true)

--- a/SubTimerTests/OrderManagerTests.swift
+++ b/SubTimerTests/OrderManagerTests.swift
@@ -18,7 +18,7 @@ struct OrderManagerTests {
     func initialState(role: PlayerOrderRole) {
         let manager = OrderManager(role: role)
         #expect(manager.role == role)
-        #expect(manager.count == 0)
+        #expect(manager.isEmpty)
         #expect(manager.nextPlayer == nil)
         #expect(manager.playerOrder.isEmpty)
     }
@@ -185,7 +185,7 @@ struct OrderManagerTests {
         manager.addPlayer(UUID())
 
         manager.clear()
-        #expect(manager.count == 0)
+        #expect(manager.isEmpty)
         #expect(manager.playerOrder.isEmpty)
     }
 
@@ -199,6 +199,6 @@ struct OrderManagerTests {
         #expect(bench.role == .bench)
         #expect(active.role == .active)
         #expect(bench.count == 1)
-        #expect(active.count == 0)
+        #expect(active.isEmpty)
     }
 }

--- a/SubTimerTests/TimerViewModelTests.swift
+++ b/SubTimerTests/TimerViewModelTests.swift
@@ -232,7 +232,7 @@ struct TimerViewModelTests {
         let players = [
             Player(name: "Player 1"),
             Player(name: "Player 2"),
-            Player(name: "Player 3"),
+            Player(name: "Player 3")
         ]
         let viewModel = await TimerViewModel(players: players)
 

--- a/SubTimerUITests/PlayerComponentsUITests.swift
+++ b/SubTimerUITests/PlayerComponentsUITests.swift
@@ -253,19 +253,21 @@ final class PlayerComponentsUITests: XCTestCase {
         XCTContext.runActivity(named: "At least one player row renders across all sections") { _ in
             XCTAssertTrue(activeRows.firstMatch.waitForExistence(timeout: 3), "Active rows should render")
             let totalCount = activeRows.count + benchRows.count + tempOutRows.count
+            let rowCountsDescription = "active: \(activeRows.count), bench: \(benchRows.count), "
+                + "tempOut: \(tempOutRows.count)"
             XCTAssertGreaterThan(
                 totalCount, 0,
-                "Should have at least one player row (active: \(activeRows.count), bench: \(benchRows.count), tempOut: \(tempOutRows.count))"
+                "Should have at least one player row (\(rowCountsDescription))"
             )
         }
 
         XCTContext.runActivity(named: "Rendered active/bench rows have unique names") { _ in
             var playerNames: Set<String> = []
-            for i in 0 ..< activeRows.count {
-                playerNames.insert(activeRows.element(boundBy: i).staticTexts.element(boundBy: 0).label)
+            for rowIndex in 0 ..< activeRows.count {
+                playerNames.insert(activeRows.element(boundBy: rowIndex).staticTexts.element(boundBy: 0).label)
             }
-            for i in 0 ..< benchRows.count {
-                playerNames.insert(benchRows.element(boundBy: i).staticTexts.element(boundBy: 0).label)
+            for rowIndex in 0 ..< benchRows.count {
+                playerNames.insert(benchRows.element(boundBy: rowIndex).staticTexts.element(boundBy: 0).label)
             }
             XCTAssertEqual(
                 playerNames.count, activeRows.count + benchRows.count,
@@ -281,6 +283,7 @@ final class PlayerComponentsUITests: XCTestCase {
     /// again - all against the same app launch, verifying the player's name
     /// survives each transition.
     @MainActor
+    // swiftlint:disable:next function_body_length
     func testPlayerRowStatusTransitionFlow() {
         let activeRows = playerRow(status: "active")
         guard activeRows.firstMatch.waitForExistence(timeout: 3) else {

--- a/SubTimerUITests/SettingsViewUITests.swift
+++ b/SubTimerUITests/SettingsViewUITests.swift
@@ -33,6 +33,13 @@
 
 import XCTest
 
+// The consolidation described above (issue #46) trades method count for
+// length in both this file and its remaining flow methods; splitting them
+// back up would undo that consolidation, so the length ceiling is disabled
+// for the rest of this file rather than elsewhere in the codebase.
+// swiftlint:disable file_length
+
+// swiftlint:disable:next type_body_length
 final class SettingsViewUITests: XCTestCase {
     /// Matches `SettingsPlayerRowView`'s `.accessibilityIdentifier`. Kept as
     /// one constant so the row query and the swipe-target query below can't
@@ -207,6 +214,7 @@ final class SettingsViewUITests: XCTestCase {
     /// there is no accessible control that enters list edit mode, so there
     /// was never any real coverage to preserve here.
     @MainActor
+    // swiftlint:disable:next function_body_length
     func testPlayerManagementFlow() {
         let initialRowCount = playerRowEditButtons().count
 
@@ -300,6 +308,7 @@ final class SettingsViewUITests: XCTestCase {
     /// picker into a single pass, plus boundary behavior at both ends of the
     /// stepper's range.
     @MainActor
+    // swiftlint:disable:next function_body_length
     func testConfigurationFlow() {
         let stepper = app.steppers.firstMatch
         XCTAssertTrue(stepper.waitForExistence(timeout: 2), "Stepper should exist")

--- a/SubTimerUITests/SubTimerUITestsLaunchTests.swift
+++ b/SubTimerUITests/SubTimerUITestsLaunchTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 
 final class SubTimerUITestsLaunchTests: XCTestCase {
-    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+    override static var runsForEachTargetApplicationUIConfiguration: Bool {
         true
     }
 

--- a/SubTimerUITests/TimerViewUITests.swift
+++ b/SubTimerUITests/TimerViewUITests.swift
@@ -17,6 +17,14 @@
 
 import XCTest
 
+// Each `test...Flow`/`testInitial...State` method below intentionally
+// consolidates several related checks into one app launch (see their
+// individual doc comments); that consolidation is what pushes this file
+// and class past SwiftLint's default length ceilings, so both are disabled
+// here rather than by splitting the flows back apart.
+// swiftlint:disable file_length
+
+// swiftlint:disable:next type_body_length
 final class TimerViewUITests: XCTestCase {
     var app: XCUIApplication!
 
@@ -85,6 +93,7 @@ final class TimerViewUITests: XCTestCase {
     /// away/back to Settings. Each condition is its own activity so a
     /// failure identifies precisely which one broke.
     @MainActor
+    // swiftlint:disable:next function_body_length
     func testInitialTimerScreenState() {
         let playPauseButton = app.buttons.matching(identifier: "timer.play.pause").firstMatch
 
@@ -128,7 +137,9 @@ final class TimerViewUITests: XCTestCase {
         }
 
         XCTContext.runActivity(named: "Player rows render with a tappable action button") { _ in
+            // XCUIElementQuery has no `isEmpty`, only `count` (an XCTest API constraint).
             XCTAssertTrue(
+                // swiftlint:disable:next empty_count
                 playerRowActionButtons().count > 0,
                 "At least one player row should render its action ('More') button"
             )
@@ -214,6 +225,7 @@ final class TimerViewUITests: XCTestCase {
     /// against the same app launch. (There is no direct "bench an active
     /// player" action in this sheet: benching only happens via substitution.)
     @MainActor
+    // swiftlint:disable:next function_body_length
     func testPlayerActionSheetFlow() {
         XCTContext.runActivity(named: "Tapping an active player's row shows its status-appropriate actions") { _ in
             let activeRowButtons = playerRowActionButtons(status: "active")
@@ -295,6 +307,7 @@ final class TimerViewUITests: XCTestCase {
     /// screen - `ManualSubstitutionSheetView` presents a plain list of bench
     /// players to sub in, titled "Select Player to Sub In".
     @MainActor
+    // swiftlint:disable:next function_body_length
     func testSubstitutionFlows() {
         XCTContext.runActivity(named: "Automatic substitution keeps the user on the Timer view") { _ in
             let subButton = app.buttons["Substitute"]
@@ -440,6 +453,8 @@ final class TimerViewUITests: XCTestCase {
 
             // Change player status
             let rowActionButtons = playerRowActionButtons()
+            // XCUIElementQuery has no `isEmpty`, only `count` (an XCTest API constraint).
+            // swiftlint:disable:next empty_count
             if rowActionButtons.count > 0 {
                 let closeButton = app.buttons["Close"]
                 rowActionButtons.element(boundBy: 0).tap()


### PR DESCRIPTION
## Summary

Closes #48.

- Adds `.swiftlint.yml` scoped to `SubTimer/`, `SubTimerTests/`, `SubTimerUITests/`, and `ActiveBench/` — SwiftLint's default rules plus a modest, commonly-adopted set of opt-in rules appropriate for a modern SwiftUI app. Build artifacts / `.build` / DerivedData / the `.xcodeproj` are excluded.
- Ran `swiftlint --fix` across the codebase, then hand-fixed what autocorrect couldn't:
  - Renamed unclear identifiers (`p1`/`p2`/`vm`/`i` → `pos1`/`pos2`/`viewModel`/`index`, etc.)
  - `for...if` → `for...where`, `first(where:) != nil` → `contains(where:)`
  - `override class var` → `override static var` in a `final class`
  - Added `OrderManager.isEmpty` (pairs with the existing `count`) since autocorrect had incorrectly rewritten `count == 0` call sites to assume an `isEmpty` that didn't exist yet
- The handful of violations autocorrect and simple renames can't fix (large SwiftUI views, the already-consolidated XCTest flows from #46, and two real API constraints — `XCUIElementQuery` has no `isEmpty`, and the throwing `#Preview` macro overload forbids the explicit `return` this preview relies on) each get a **targeted, documented `swiftlint:disable` directive** with an inline comment explaining why, rather than a rule-wide threshold change.
- `swiftlint lint --strict` now returns **zero violations**.
- README.md documents how to install (`brew install swiftlint`) and run (`swiftlint lint --strict`, `swiftlint --fix`) it locally.

## Verification

- `swiftlint lint --strict` → 0 violations, 0 serious, 48 files.
- Full `xcodebuild test` (58 unit tests + 23 UI tests) passes. One UI test (`PlayerComponentsUITests.testPlayerRowStatusTransitionFlow`) flaked once in a full-suite run but passed both standalone and in a targeted re-run of its whole suite — confirmed as a pre-existing timing flake, not a regression from this change.
- Diff reviewed against both Standards (Fowler smell baseline) and Spec (issue #48 acceptance criteria) axes; the initial pass raised rule-wide length thresholds, which review correctly flagged as too blanket a change — replaced with the targeted per-site `swiftlint:disable` directives described above.

## Acceptance criteria

- [x] A SwiftLint config exists covering all Swift source in `SubTimer/`, `SubTimerTests/`, `SubTimerUITests/`, and `ActiveBench/`
- [x] `swiftlint lint --strict` run from the repo root returns zero violations
- [x] Any exclusions/baselines are intentional and documented with a reason, not blanket rule disabling
- [x] A short doc note explains how to install and run SwiftLint locally