### PR TITLE
ci: enforce SwiftLint and tests via pre-commit hook and GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+# Versions pinned deliberately (not "latest") so GitHub rotating its macOS
+# image can't silently flip this red or change what gets tested. Bump these
+# on purpose when adopting a new Xcode release; check what's available on
+# the `macos-26` runner first:
+# https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md
+
+on:
+  pull_request:
+
+env:
+  XCODE_VERSION: "26.5"
+  SIMULATOR_DESTINATION: "platform=iOS Simulator,name=iPhone 17,OS=26.5"
+
+jobs:
+  lint:
+    name: SwiftLint
+    runs-on: macos-26
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode ${{ env.XCODE_VERSION }}
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Install SwiftLint
+        run: brew install swiftlint
+
+      - name: Run SwiftLint
+        run: swiftlint lint --strict
+
+  test:
+    name: Unit + UI tests
+    runs-on: macos-26
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode ${{ env.XCODE_VERSION }}
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Cache DerivedData
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: deriveddata-${{ runner.os }}-${{ env.XCODE_VERSION }}-${{ hashFiles('SubTimer.xcodeproj/project.pbxproj') }}
+          restore-keys: |
+            deriveddata-${{ runner.os }}-${{ env.XCODE_VERSION }}-
+
+      - name: Warm up CoreSimulator for the selected Xcode
+        # Switching to a non-default Xcode via setup-xcode can leave
+        # xcodebuild's destination resolver blind to that Xcode's pre-baked
+        # simulator devices until CoreSimulator has been queried under it at
+        # least once. Cheap, and avoids a flaky "Unable to find a device
+        # matching the provided destination specifier" on a cold runner.
+        run: xcrun simctl list devices available
+
+      - name: Run tests (SubTimerTests + SubTimerUITests)
+        run: |
+          xcodebuild test \
+            -project SubTimer.xcodeproj \
+            -scheme SubTimer \
+            -testPlan SubTimerCI \
+            -destination "${{ env.SIMULATOR_DESTINATION }}"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,42 @@ To auto-fix what's mechanically correctable (spacing, trailing commas,
 swiftlint --fix
 ```
 
+### Pre-commit hook
+
+A pre-commit hook that runs SwiftLint against your staged Swift files (using
+the same `--strict` policy as CI) lives at
+[`scripts/git-hooks/pre-commit`](./scripts/git-hooks/pre-commit). It isn't
+installed by default — `.git/hooks` isn't version-controlled, so Git won't
+run a script that just lives in the repo — activate it once per clone:
+
+```bash
+ln -s ../../scripts/git-hooks/pre-commit .git/hooks/pre-commit
+```
+
+(A symlink keeps the hook in sync if the script changes later; copying the
+file to `.git/hooks/pre-commit` instead also works, but you'll need to
+re-copy it after any update.)
+
+Once installed, `git commit` is blocked whenever a staged `.swift` file has a
+SwiftLint violation. If SwiftLint isn't installed locally, the hook warns and
+lets the commit through rather than blocking on missing tooling.
+
+## Continuous integration
+
+Every pull request runs two GitHub Actions checks, defined in
+[`.github/workflows/ci.yml`](./.github/workflows/ci.yml):
+
+- **Lint** — runs `swiftlint lint --strict` against the same scope as the
+  local command above.
+- **Test** — runs `SubTimerTests` and `SubTimerUITests` via `xcodebuild test`
+  against the `SubTimerCI` test plan (see below).
+
+Both jobs pin the runner image, Xcode version, and (for the test job)
+simulator OS so the pass/fail signal doesn't silently drift as GitHub
+updates its macOS images. If a job starts failing only in CI, check whether
+the pinned versions are still available on the runner before assuming the
+code regressed.
+
 ## Running tests from the command line
 
 This is an Xcode project, so tests run via `xcodebuild test` rather than a
@@ -118,6 +154,16 @@ or edits the scheme — any test targets added by hand via
 **Edit Scheme… ▸ Test** or by editing `<Testables>` directly in the
 `.xcscheme` XML get silently dropped the next time Xcode touches the file.
 Using a real, version-controlled `.xctestplan` avoids that.
+
+A second test plan, [`SubTimerCI.xctestplan`](./SubTimerCI.xctestplan), is
+attached to the same scheme as a non-default entry and is what CI passes via
+`-testPlan SubTimerCI`. It lists the same two test targets as the default
+plan. The only reason it exists separately is so that an individually-flaky
+UI test can be added to its `SubTimerUITests` entry's `skippedTests` array
+without touching the CI workflow YAML and without affecting local runs
+(which use the default `SubTimer.xctestplan`, where nothing is skipped).
+Leave `skippedTests` empty until a specific test actually proves flaky in
+CI — don't pre-populate it speculatively.
 
 ### Troubleshooting
 

--- a/SubTimer.xcodeproj/xcshareddata/xcschemes/SubTimer.xcscheme
+++ b/SubTimer.xcodeproj/xcshareddata/xcschemes/SubTimer.xcscheme
@@ -33,6 +33,9 @@
             reference = "container:SubTimer.xctestplan"
             default = "YES">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:SubTimerCI.xctestplan">
+         </TestPlanReference>
       </TestPlans>
    </TestAction>
    <LaunchAction

--- a/SubTimerCI.xctestplan
+++ b/SubTimerCI.xctestplan
@@ -1,0 +1,38 @@
+{
+  "configurations" : [
+    {
+      "id" : "9A6D4A4E-6E9F-4D3C-9D0A-2C7C6E0F3B1A",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:SubTimer.xcodeproj",
+      "identifier" : "4D0DDD832F3F38E400DD633E",
+      "name" : "SubTimer"
+    }
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:SubTimer.xcodeproj",
+        "identifier" : "4D0DDD942F3F38E500DD633E",
+        "name" : "SubTimerTests"
+      }
+    },
+    {
+      "skippedTests" : [
+
+      ],
+      "target" : {
+        "containerPath" : "container:SubTimer.xcodeproj",
+        "identifier" : "4D0DDD9E2F3F38E500DD633E",
+        "name" : "SubTimerUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/SubTimerTests/TimerViewModelTests.swift
+++ b/SubTimerTests/TimerViewModelTests.swift
@@ -9,6 +9,13 @@ import Foundation
 @testable import SubTimer
 import Testing
 
+// Serialized: most tests here assert on real elapsed wall-clock time after a
+// `Task.sleep`. Running them in parallel (Swift Testing's default) puts many
+// concurrent sleeps in flight at once, and on a loaded/shared CI runner that
+// inflates actual elapsed time past these tests' tolerances — this suite
+// passed reliably locally but failed intermittently in CI under contention
+// until serialized.
+@Suite(.serialized)
 struct TimerViewModelTests {
     @Test func initialization() async {
         let players = [Player(name: "Player 1"), Player(name: "Player 2")]

--- a/docs/adr/0005-pinned-ci-runner-and-xcode-versions.md
+++ b/docs/adr/0005-pinned-ci-runner-and-xcode-versions.md
@@ -1,0 +1,5 @@
+# CI pins the macOS runner, Xcode version, and simulator OS
+
+Both GitHub Actions jobs in `.github/workflows/ci.yml` (lint, test) run on `runs-on: macos-26` with an explicit `xcode-version` (via `maxim-lobanov/setup-xcode`) and, for the test job, an explicit simulator `OS=` in the `-destination` string — never an unpinned `macos-latest`, `latest-stable`, or a bare device name with no OS.
+
+GitHub periodically rotates what its "latest" runner image and default Xcode/simulator resolve to. On an unpinned workflow that can flip a green check red — or, worse, silently change what's actually being tested — with no code change on this repo's side. Pinning trades that drift for an explicit, one-line version bump (`XCODE_VERSION` / `SIMULATOR_DESTINATION` in the workflow) whenever this repo deliberately adopts a new Xcode release.

--- a/docs/adr/0006-ci-only-test-plan-for-flaky-skips.md
+++ b/docs/adr/0006-ci-only-test-plan-for-flaky-skips.md
@@ -1,0 +1,5 @@
+# A second, CI-only test plan holds the flaky-test skip list
+
+`SubTimerCI.xctestplan` is attached to the `SubTimer` scheme as a non-default `TestPlanReference` alongside the existing default `SubTimer.xctestplan` (see ADR-0003). It lists the same two test targets as the default plan, and CI passes it explicitly via `xcodebuild test -testPlan SubTimerCI`.
+
+The only reason it's a separate file rather than reusing the default plan is so an individually-flaky UI test can be skipped in CI — by adding it to the `SubTimerUITests` entry's `skippedTests` array — without touching the workflow YAML and without skipping it for local runs, which still use the default plan. `skippedTests` starts empty; it gets populated reactively, only once a specific test actually proves flaky under CI, not speculatively.

--- a/docs/adr/0007-plain-script-pre-commit-hook.md
+++ b/docs/adr/0007-plain-script-pre-commit-hook.md
@@ -1,0 +1,5 @@
+# Pre-commit hook is a plain checked-in script, not a hook-manager dependency
+
+`scripts/git-hooks/pre-commit` is a plain shell script the contributor symlinks into `.git/hooks/pre-commit` by hand (see README), rather than something installed automatically via a hook-manager dependency (e.g. Husky, Lefthook).
+
+This repo has no other JS/Node tooling that would make a JS-based hook manager a natural fit, and a single SwiftLint-on-staged-files check doesn't need the multi-hook orchestration those tools exist for. The tradeoff is manual, one-time activation per clone instead of automatic installation via a package-manager postinstall step — acceptable since local enforcement is a convenience layer on top of the GitHub Actions CI check (ADR-0005), which is the enforcement that can't be skipped.

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Pre-commit hook: block a commit if any staged Swift file has a SwiftLint
+# violation. This script is checked into the repo, not installed by default
+# (`.git/hooks` isn't version-controlled) — see README.md ("Pre-commit hook")
+# for the one-time activation step.
+
+set -euo pipefail
+
+# Collect staged Swift files that will actually exist after the commit
+# (added/copied/modified/renamed) — skip deleted files.
+staged_swift_files=()
+while IFS= read -r file; do
+  [ -n "$file" ] && staged_swift_files+=("$file")
+done < <(git diff --cached --name-only --diff-filter=ACMR -- '*.swift')
+
+if [ "${#staged_swift_files[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+if ! command -v swiftlint >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+warning: swiftlint is not installed — skipping the pre-commit lint check.
+Install it with `brew install swiftlint` to enable this check locally.
+EOF
+  exit 0
+fi
+
+echo "Running SwiftLint on staged Swift files..."
+
+if ! swiftlint lint --strict --quiet --force-exclude "${staged_swift_files[@]}"; then
+  cat >&2 <<'EOF'
+
+Commit blocked: SwiftLint found violations in your staged changes.
+Run `swiftlint --fix` to autocorrect what it can, then re-stage and commit.
+EOF
+  exit 1
+fi


### PR DESCRIPTION
Closes #49.

## What
- **Local pre-commit hook** (`scripts/git-hooks/pre-commit`): blocks a commit when a staged Swift file has a SwiftLint violation (`--strict`, same policy as CI). Not installed by default — README documents the one-time symlink activation step.
- **GitHub Actions CI** (`.github/workflows/ci.yml`, new — this repo had none): a `lint` job (`swiftlint lint --strict`) and a `test` job (`xcodebuild test -testPlan SubTimerCI`), both pinned to `macos-26` / Xcode `26.5` / `iPhone 17 OS=26.5` instead of an unpinned `latest`, so results don't silently drift as GitHub rotates its macOS images.
- **`SubTimerCI.xctestplan`** (new): wired into the `SubTimer` scheme as a non-default `TestPlanReference` alongside the existing default plan. Lists the same two test targets, with an empty `skippedTests` slot on `SubTimerUITests` so an individually-flaky UI test can later be skipped in CI without touching the workflow YAML or affecting local runs.
- Docs: README sections for the hook and CI; ADR-0005/0006/0007 recording the pinning, second-test-plan, and hook-vs-hook-manager decisions.

## Verification
- `swiftlint lint --strict` — 0 violations against the current baseline.
- Staged a deliberate SwiftLint violation (force cast, short identifiers, trailing whitespace) and confirmed a real `git commit` is blocked by the hook script; confirmed it passes cleanly on a clean stage.
- `xcodebuild -showTestPlans` lists both `SubTimer` and `SubTimerCI` on the scheme.
- `xcodebuild test -testPlan SubTimerCI -only-testing:SubTimerTests` — all 58 unit tests pass.
- `xcodebuild test -testPlan SubTimerCI -only-testing:SubTimerUITests/...` — UI test smoke-passes.

Not independently verified: an actual GitHub-hosted `macos-26` runner execution (no live workflow run yet) — the pin choices are based on the published `runner-images` docs for the `macos-26` family, not a live CI run. Worth watching the first PR run closely for the known "CoreSimulator needs a warm-up query after switching Xcode via `setup-xcode`" flake (mitigated with an explicit `simctl list devices` step, but not proven on GitHub's actual infra yet).