### PR TITLE
style: harden PlayerStatus and PlayerOrderRole with explicit raw values

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,6 +22,14 @@ excluded:
   - .build
   - SubTimer.xcodeproj
 
+# redundant_string_enum_value (on by default) is the mirror image of
+# explicit_enum_raw_value below: it flags raw values that match the case
+# name as omittable, while explicit_enum_raw_value requires every case to
+# have one. We want explicit raw values on persisted enums (see issue #67),
+# so the default rule is disabled in favor of the opt-in one.
+disabled_rules:
+  - redundant_string_enum_value
+
 opt_in_rules:
   - closure_end_indentation
   - closure_spacing
@@ -33,6 +41,7 @@ opt_in_rules:
   - discouraged_optional_boolean
   - empty_count
   - empty_string
+  - explicit_enum_raw_value
   - fallthrough
   - first_where
   - identical_operands

--- a/SubTimer/Models/OrderManager.swift
+++ b/SubTimer/Models/OrderManager.swift
@@ -9,8 +9,8 @@ import Foundation
 import SwiftData
 
 enum PlayerOrderRole: String, Codable {
-    case bench
-    case active
+    case bench = "bench"
+    case active = "active"
 }
 
 @Model

--- a/SubTimer/Models/Player.swift
+++ b/SubTimer/Models/Player.swift
@@ -41,7 +41,7 @@ final class Player {
 }
 
 enum PlayerStatus: String, Codable {
-    case active
-    case benched
-    case temporarilyOut
+    case active = "active"
+    case benched = "benched"
+    case temporarilyOut = "temporarilyOut"
 }


### PR DESCRIPTION
## What

Add explicit `String` raw values to every case of `PlayerStatus` (`Player.swift`) and `PlayerOrderRole` (`OrderManager.swift`), both SwiftData-persisted enums that previously relied on implicit raw values inferred from case name.

## Why

Without explicit raw values, reordering or renaming a case later silently shifts what gets stored on disk for existing rosters/sessions, with no compile-time warning. Explicit raw values remove that risk permanently.

## Changes

- `PlayerStatus`: `active`, `benched`, `temporarilyOut` each get `= "..."` matching the current implicit value (no behavior change).
- `PlayerOrderRole`: `bench`, `active` each get `= "..."` matching the current implicit value (no behavior change).
- `.swiftlint.yml`: enabled `explicit_enum_raw_value` (opt-in) to enforce this going forward; disabled the default `redundant_string_enum_value` rule, since it's the mirror image of `explicit_enum_raw_value` and would otherwise flag the exact raw values the new rule requires. Rationale documented inline.

## Verification

- `swiftlint lint --strict`: 0 violations across all 48 linted files.
- Unit tests: 58/58 pass, including `PlayerStatusTests` and `OrderManagerTests`, which assert `.rawValue` equals the case name string — confirming no behavior change.
- UI tests: 12 failures observed, independently confirmed to be pre-existing environment/timing flakiness (e.g. a Stepper not appearing in time; one failure's crash log even resolved to a source path from an unrelated worktree, pointing to stale/shared DerivedData) — not caused by this change.

Closes #67