### PR TITLE
fix: add accessibility labels for icon-only images

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -23,6 +23,7 @@ excluded:
   - SubTimer.xcodeproj
 
 opt_in_rules:
+  - accessibility_label_for_image
   - closure_end_indentation
   - closure_spacing
   - collection_alignment

--- a/SubTimer/Views/Components/Players/ActivePlayerRowView.swift
+++ b/SubTimer/Views/Components/Players/ActivePlayerRowView.swift
@@ -27,6 +27,7 @@ struct ActivePlayerRowView: View {
                         Image(systemName: "arrow.down.circle.fill")
                             .foregroundStyle(.appOrange)
                             .font(.caption)
+                            .accessibilityLabel("Next to Sub Out")
                     }
                 }
                 Text(TimeFormatter.format(player.currentPlayDuration))

--- a/SubTimer/Views/Components/Players/BenchPlayerRowView.swift
+++ b/SubTimer/Views/Components/Players/BenchPlayerRowView.swift
@@ -36,6 +36,7 @@ struct BenchPlayerRowView: View {
                         Image(systemName: "arrow.up.circle.fill")
                             .foregroundStyle(.green)
                             .font(.caption)
+                            .accessibilityLabel("Next Up")
                     }
                 }
                 Text("Total: \(TimeFormatter.format(player.totalPlayTime))")
@@ -61,6 +62,7 @@ struct BenchPlayerRowView: View {
                         .foregroundStyle(.green)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Activate")
             }
         }
         .padding()

--- a/SubTimer/Views/Components/Timer/PreferredTimeDisplayView.swift
+++ b/SubTimer/Views/Components/Timer/PreferredTimeDisplayView.swift
@@ -46,6 +46,7 @@ struct PreferredTimeDisplayView: View {
             if hasPreferredTime {
                 HStack(spacing: 4) {
                     Image(systemName: isOverTime ? "exclamationmark.triangle.fill" : "clock")
+                        .accessibilityHidden(true)
                     Text(timeRemainingText)
                 }
                 .font(.subheadline)

--- a/SubTimer/Views/Components/Timer/SubstitutionButtonView.swift
+++ b/SubTimer/Views/Components/Timer/SubstitutionButtonView.swift
@@ -21,6 +21,7 @@ struct SubstitutionButtonView: View {
             HStack {
                 Image(systemName: "arrow.left.arrow.right.circle.fill")
                     .font(.headline)
+                    .accessibilityHidden(true)
                 Text("Substitute")
                     .font(.headline)
                     .bold()

--- a/SubTimer/Views/Components/Timer/TimerControlsView.swift
+++ b/SubTimer/Views/Components/Timer/TimerControlsView.swift
@@ -23,6 +23,7 @@ struct TimerControlsView: View {
                 HStack {
                     Image(systemName: isRunning ? "pause.circle.fill" : "play.circle.fill")
                         .font(.system(size: 30))
+                        .accessibilityHidden(true)
                     Text(isRunning ? "Pause" : "Start")
                         .font(.title2)
                         .bold()
@@ -38,6 +39,7 @@ struct TimerControlsView: View {
                 HStack {
                     Image(systemName: "arrow.clockwise.circle.fill")
                         .font(.system(size: 30))
+                        .accessibilityHidden(true)
                     Text("Reset")
                         .font(.title2)
                         .bold()


### PR DESCRIPTION
## What

Enables SwiftLint's `accessibility_label_for_image` opt-in rule (previously not in `opt_in_rules:`) and gives every flagged icon a deliberate per-icon decision, rather than a blanket default.

## Decisions

- **`ActivePlayerRowView`** — "next to sub out" arrow (shown only when `isNextToSubOut`, no adjacent text describes it) → `.accessibilityLabel("Next to Sub Out")`.
- **`BenchPlayerRowView`** — "next up" arrow (shown only when `isNextUp && !canActivate`, no adjacent text) → `.accessibilityLabel("Next Up")`.
- **`BenchPlayerRowView`** — activate button (no adjacent text; sibling "More" button already labels itself) → `.accessibilityLabel("Activate")` on the `Button`, matching the existing "More" button-level-label pattern.
- **`SubstitutionButtonView`** — icon sits inside the same `Button` as `Text("Substitute")` → `.accessibilityHidden(true)` (redundant with visible text).
- **`TimerControlsView`** — play/pause icon and reset icon, each inside a `Button` alongside matching `Text` → both `.accessibilityHidden(true)`.
- **`PreferredTimeDisplayView`** — warning-triangle/clock icon beside `Text(timeRemainingText)` (e.g. "Over by 1:00" / "Preferred: 3:00") → `.accessibilityHidden(true)` (redundant with visible text).

Title-case wording ("Next Up", "Next to Sub Out") matches this codebase's existing action/status string convention (`Mark Temporarily Out`, `Return to Bench`, `Activate Player`) and `CONTEXT.md`'s glossary term "Next Up".

## Verification

- `swiftlint lint --strict`: 0 violations (48 files), including 0 `accessibility_label_for_image` violations.
- `SubTimerTests`: 58/58 passed.
- `SubTimerUITests`: hit pre-existing simulator crash/restart flakiness during this run; reproduced the identical crash against unmodified baseline code (via `git stash`), confirming it's unrelated to this diff, not a regression.
- Two-axis code review (Standards + Spec, parallel sub-agents): no hard violations, no scope creep, no missing icons. Only minor judgement-call notes, addressed (wording case alignment).

## Remaining manual step

Per the issue's own acceptance criteria: a human spot-check with VoiceOver or Accessibility Inspector confirming each icon announces something sensible. Not something this sandbox can perform.

Closes #68