### PR TITLE
Extract long closures flagged by closure_body_length

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -32,6 +32,7 @@ disabled_rules:
 
 opt_in_rules:
   - accessibility_label_for_image
+  - closure_body_length
   - closure_end_indentation
   - closure_spacing
   - collection_alignment

--- a/ActiveBench/ActiveBenchLiveActivity.swift
+++ b/ActiveBench/ActiveBenchLiveActivity.swift
@@ -15,128 +15,167 @@ import WidgetKit
 struct ActiveBenchLiveActivity: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: ActiveBenchAttributes.self) { context in
-            VStack(spacing: 12) {
-                VStack(spacing: 4) {
-                    Text("Current Play Time")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+            lockScreenView(context: context)
+        } dynamicIsland: { context in
+            dynamicIsland(context: context)
+        }
+    }
 
-                    HStack(alignment: .firstTextBaseline, spacing: 12) {
-                        if context.state.isRunning {
-                            Text(context.state.timerRefDate, style: .timer)
-                                .font(.system(size: 32, weight: .bold, design: .rounded))
-                                .monospacedDigit()
-                                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
-                        } else {
-                            Text(formatTime(context.state.accumulatedTime))
-                                .font(.system(size: 32, weight: .bold, design: .rounded))
-                                .monospacedDigit()
-                                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
-                        }
+    // MARK: - Lock Screen / Banner
 
-                        if let subOut = context.state.subOutPlayerName,
-                            let subIn = context.state.subInPlayerName {
-                            Text("\(subOut) → \(subIn)")
-                                .font(.system(size: 16, weight: .semibold, design: .rounded))
-                                .foregroundStyle(Color("AppOrange"))
-                                .lineLimit(1)
-                        }
-                    }
-                }
+    private func lockScreenView(context: ActivityViewContext<ActiveBenchAttributes>) -> some View {
+        VStack(spacing: 12) {
+            timeDisplay(context: context)
+            playerCountsRow(context: context)
+        }
+        .padding()
+        .activityBackgroundTint(Color(uiColor: .systemBackground))
+        .activitySystemActionForegroundColor(Color.primary)
+    }
 
-                HStack(spacing: 16) {
-                    Image(systemName: context.state.isRunning ? "play.circle.fill" : "pause.circle.fill")
-                        .foregroundStyle(context.state.isRunning ? .green : Color("AppOrange"))
-
-                    HStack(spacing: 4) {
-                        Image(systemName: "person.3.fill")
-                        Text("\(context.state.activePlayersCount) Active")
-                    }
-
-                    HStack(spacing: 4) {
-                        Image(systemName: "figure.seated")
-                        Text("\(context.state.benchedPlayersCount) Bench")
-                    }
-                }
+    private func timeDisplay(context: ActivityViewContext<ActiveBenchAttributes>) -> some View {
+        VStack(spacing: 4) {
+            Text("Current Play Time")
                 .font(.caption)
                 .foregroundStyle(.secondary)
-            }
-            .padding()
-            .activityBackgroundTint(Color(uiColor: .systemBackground))
-            .activitySystemActionForegroundColor(Color.primary)
-        } dynamicIsland: { context in
-            DynamicIsland {
-                DynamicIslandExpandedRegion(.leading) {
-                    HStack(spacing: 12) {
-                        HStack(spacing: 4) {
-                            Image(systemName: "person.3.fill")
-                            Text("\(context.state.activePlayersCount)")
-                        }
 
-                        HStack(spacing: 4) {
-                            Image(systemName: "figure.seated")
-                            Text("\(context.state.benchedPlayersCount)")
-                        }
-                    }
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+            HStack(alignment: .firstTextBaseline, spacing: 12) {
+                if context.state.isRunning {
+                    Text(context.state.timerRefDate, style: .timer)
+                        .font(.system(size: 32, weight: .bold, design: .rounded))
+                        .monospacedDigit()
+                        .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+                } else {
+                    Text(formatTime(context.state.accumulatedTime))
+                        .font(.system(size: 32, weight: .bold, design: .rounded))
+                        .monospacedDigit()
+                        .foregroundStyle(isOvertime(context.state) ? .red : .primary)
                 }
 
-                DynamicIslandExpandedRegion(.bottom) {
-                    VStack(spacing: 4) {
-                        if context.state.isRunning {
-                            Text(context.state.timerRefDate, style: .timer)
-                                .font(.system(size: 36, weight: .bold, design: .rounded))
-                                .monospacedDigit()
-                                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
-                        } else {
-                            Text(formatTime(context.state.accumulatedTime))
-                                .font(.system(size: 36, weight: .bold, design: .rounded))
-                                .monospacedDigit()
-                                .foregroundStyle(isOvertime(context.state) ? .red : .primary)
-                        }
-
-                        if let subOut = context.state.subOutPlayerName,
-                            let subIn = context.state.subInPlayerName {
-                            Text("\(subOut) → \(subIn)")
-                                .font(.system(size: 20, weight: .semibold, design: .rounded))
-                                .foregroundStyle(Color("AppOrange"))
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.7)
-                        }
-                    }
-                    .frame(maxWidth: .infinity)
-                }
-            } compactLeading: {
-                HStack(spacing: 2) {
-                    Image(systemName: context.state.isRunning ? "play.fill" : "pause.fill")
-                        .font(.caption2)
-                    if context.state.isRunning {
-                        Text(context.state.timerRefDate, style: .timer)
-                            .font(.caption2)
-                            .monospacedDigit()
-                            .foregroundStyle(isOvertime(context.state) ? .red : .primary)
-                    } else {
-                        Text(formatTimeCompact(context.state.accumulatedTime))
-                            .font(.caption2)
-                            .monospacedDigit()
-                            .foregroundStyle(isOvertime(context.state) ? .red : .primary)
-                    }
-                }
-            } compactTrailing: {
                 if let subOut = context.state.subOutPlayerName,
                     let subIn = context.state.subInPlayerName {
                     Text("\(subOut) → \(subIn)")
-                        .font(.system(size: 12))
+                        .font(.system(size: 16, weight: .semibold, design: .rounded))
                         .foregroundStyle(Color("AppOrange"))
                         .lineLimit(1)
                 }
-            } minimal: {
-                Image(systemName: context.state.isRunning ? "play.circle.fill" : "pause.circle.fill")
-                    .foregroundStyle(context.state.isRunning ? .green : Color("AppOrange"))
             }
-            .keylineTint(context.state.isRunning ? .green : Color("AppOrange"))
         }
+    }
+
+    private func playerCountsRow(context: ActivityViewContext<ActiveBenchAttributes>) -> some View {
+        HStack(spacing: 16) {
+            Image(systemName: context.state.isRunning ? "play.circle.fill" : "pause.circle.fill")
+                .foregroundStyle(context.state.isRunning ? .green : Color("AppOrange"))
+
+            HStack(spacing: 4) {
+                Image(systemName: "person.3.fill")
+                Text("\(context.state.activePlayersCount) Active")
+            }
+
+            HStack(spacing: 4) {
+                Image(systemName: "figure.seated")
+                Text("\(context.state.benchedPlayersCount) Bench")
+            }
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+
+    // MARK: - Dynamic Island
+
+    private func dynamicIsland(context: ActivityViewContext<ActiveBenchAttributes>) -> DynamicIsland {
+        DynamicIsland {
+            DynamicIslandExpandedRegion(.leading) {
+                expandedLeading(context: context)
+            }
+            DynamicIslandExpandedRegion(.bottom) {
+                expandedBottom(context: context)
+            }
+        } compactLeading: {
+            compactLeading(context: context)
+        } compactTrailing: {
+            compactTrailing(context: context)
+        } minimal: {
+            minimal(context: context)
+        }
+        .keylineTint(context.state.isRunning ? .green : Color("AppOrange"))
+    }
+
+    private func expandedLeading(context: ActivityViewContext<ActiveBenchAttributes>) -> some View {
+        HStack(spacing: 12) {
+            HStack(spacing: 4) {
+                Image(systemName: "person.3.fill")
+                Text("\(context.state.activePlayersCount)")
+            }
+
+            HStack(spacing: 4) {
+                Image(systemName: "figure.seated")
+                Text("\(context.state.benchedPlayersCount)")
+            }
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+
+    private func expandedBottom(context: ActivityViewContext<ActiveBenchAttributes>) -> some View {
+        VStack(spacing: 4) {
+            if context.state.isRunning {
+                Text(context.state.timerRefDate, style: .timer)
+                    .font(.system(size: 36, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+            } else {
+                Text(formatTime(context.state.accumulatedTime))
+                    .font(.system(size: 36, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+            }
+
+            if let subOut = context.state.subOutPlayerName,
+                let subIn = context.state.subInPlayerName {
+                Text("\(subOut) → \(subIn)")
+                    .font(.system(size: 20, weight: .semibold, design: .rounded))
+                    .foregroundStyle(Color("AppOrange"))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func compactLeading(context: ActivityViewContext<ActiveBenchAttributes>) -> some View {
+        HStack(spacing: 2) {
+            Image(systemName: context.state.isRunning ? "play.fill" : "pause.fill")
+                .font(.caption2)
+            if context.state.isRunning {
+                Text(context.state.timerRefDate, style: .timer)
+                    .font(.caption2)
+                    .monospacedDigit()
+                    .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+            } else {
+                Text(formatTimeCompact(context.state.accumulatedTime))
+                    .font(.caption2)
+                    .monospacedDigit()
+                    .foregroundStyle(isOvertime(context.state) ? .red : .primary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func compactTrailing(context: ActivityViewContext<ActiveBenchAttributes>) -> some View {
+        if let subOut = context.state.subOutPlayerName,
+            let subIn = context.state.subInPlayerName {
+            Text("\(subOut) → \(subIn)")
+                .font(.system(size: 12))
+                .foregroundStyle(Color("AppOrange"))
+                .lineLimit(1)
+        }
+    }
+
+    private func minimal(context: ActivityViewContext<ActiveBenchAttributes>) -> some View {
+        Image(systemName: context.state.isRunning ? "play.circle.fill" : "pause.circle.fill")
+            .foregroundStyle(context.state.isRunning ? .green : Color("AppOrange"))
     }
 
     // MARK: - Helper Functions

--- a/SubTimer/SubTimerApp.swift
+++ b/SubTimer/SubTimerApp.swift
@@ -10,7 +10,18 @@ import SwiftUI
 
 @main
 struct SubTimerApp: App {
-    var sharedModelContainer: ModelContainer = {
+    var sharedModelContainer: ModelContainer = Self.makeModelContainer()
+
+    var body: some Scene {
+        WindowGroup {
+            MainTabView()
+        }
+        .modelContainer(sharedModelContainer)
+    }
+
+    // MARK: - Model Container Setup
+
+    private static func makeModelContainer() -> ModelContainer {
         let schema = Schema([
             Player.self,
             AppConfiguration.self,
@@ -36,38 +47,44 @@ struct SubTimerApp: App {
 
             return container
         } catch {
-            // Migration failed - delete the old database and create a new one
             print("ModelContainer creation failed: \(error)")
-            print("Attempting to delete old database and create new one...")
-
-            // Delete the existing database files
-            let url = modelConfiguration.url
-            try? FileManager.default.removeItem(at: url)
-            try? FileManager.default.removeItem(
-                at: url.deletingPathExtension().appendingPathExtension("sqlite-shm")
+            return recoverModelContainer(
+                schema: schema,
+                modelConfiguration: modelConfiguration,
+                isUITesting: isUITesting
             )
-            try? FileManager.default.removeItem(
-                at: url.deletingPathExtension().appendingPathExtension("sqlite-wal")
-            )
+        }
+    }
 
-            // Try creating container again
-            do {
-                let container = try ModelContainer(for: schema, configurations: [modelConfiguration])
-                if isUITesting {
-                    setupTestData(in: container)
-                }
-                return container
-            } catch {
-                fatalError("Could not create ModelContainer even after cleanup: \(error)")
+    /// Deletes the existing database files and retries container creation.
+    /// Called when the initial `ModelContainer` creation fails, most likely
+    /// due to a schema migration that SwiftData couldn't perform in place.
+    private static func recoverModelContainer(
+        schema: Schema,
+        modelConfiguration: ModelConfiguration,
+        isUITesting: Bool
+    ) -> ModelContainer {
+        print("Attempting to delete old database and create new one...")
+
+        // Delete the existing database files
+        let url = modelConfiguration.url
+        try? FileManager.default.removeItem(at: url)
+        try? FileManager.default.removeItem(
+            at: url.deletingPathExtension().appendingPathExtension("sqlite-shm")
+        )
+        try? FileManager.default.removeItem(
+            at: url.deletingPathExtension().appendingPathExtension("sqlite-wal")
+        )
+
+        do {
+            let container = try ModelContainer(for: schema, configurations: [modelConfiguration])
+            if isUITesting {
+                setupTestData(in: container)
             }
+            return container
+        } catch {
+            fatalError("Could not create ModelContainer even after cleanup: \(error)")
         }
-    }()
-
-    var body: some Scene {
-        WindowGroup {
-            MainTabView()
-        }
-        .modelContainer(sharedModelContainer)
     }
 
     // MARK: - Test Data Setup

--- a/SubTimer/Views/Components/Players/ActivePlayersSectionView.swift
+++ b/SubTimer/Views/Components/Players/ActivePlayersSectionView.swift
@@ -20,66 +20,70 @@ struct ActivePlayersSectionView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            // Header
-            HStack {
-                Label("Active Players", systemImage: "figure.run")
-                    .font(.title3)
-                    .bold()
-                Spacer()
-                Text("\(players.count)/\(maxActiveCount)")
-                    .foregroundStyle(.secondary)
-            }
+            headerView
 
-            // Content
             if players.isEmpty {
                 emptyStateView
             } else if onReorder != nil {
-                List {
-                    ForEach(Array(players.enumerated()), id: \.element.id) { index, player in
-                        ActivePlayerRowView(
-                            player: player,
-                            isNextToSubOut: isNextToSubOut(index),
-                            onTap: { onPlayerTap(player) }
-                        )
-                        .listRowInsets(EdgeInsets())
-                        .listRowSeparator(.hidden)
-                        .listRowBackground(
-                            isNextToSubOut(index)
-                                ? RoundedRectangle(cornerRadius: 12).fill(Color.appOrange.opacity(0.1))
-                                : RoundedRectangle(cornerRadius: 12).fill(
-                                    Color(uiColor: .secondarySystemBackground)
-                                )
-                        )
-                    }
-                    .onMove(perform: movePlayer)
-                }
-                .listStyle(.plain)
-                .listRowSpacing(8)
-                .environment(\.editMode, .constant(.active))
-                .frame(height: CGFloat(players.count) * 80)
+                reorderableListView
             } else {
-                LazyVStack(spacing: 8) {
-                    ForEach(Array(players.enumerated()), id: \.element.id) { index, player in
-                        ActivePlayerRowView(
-                            player: player,
-                            isNextToSubOut: isNextToSubOut(index),
-                            onTap: { onPlayerTap(player) }
-                        )
-                        .padding(.horizontal, 4)
-                        .background(
-                            isNextToSubOut(index)
-                                ? RoundedRectangle(cornerRadius: 12).fill(Color.appOrange.opacity(0.1))
-                                : RoundedRectangle(cornerRadius: 12).fill(
-                                    Color(uiColor: .secondarySystemBackground)
-                                )
-                        )
-                    }
-                }
+                staticListView
             }
         }
     }
 
     // MARK: - Helper Views
+
+    private var headerView: some View {
+        HStack {
+            Label("Active Players", systemImage: "figure.run")
+                .font(.title3)
+                .bold()
+            Spacer()
+            Text("\(players.count)/\(maxActiveCount)")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var reorderableListView: some View {
+        List {
+            ForEach(Array(players.enumerated()), id: \.element.id) { index, player in
+                playerRow(player: player, index: index)
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(rowBackground(index: index))
+            }
+            .onMove(perform: movePlayer)
+        }
+        .listStyle(.plain)
+        .listRowSpacing(8)
+        .environment(\.editMode, .constant(.active))
+        .frame(height: CGFloat(players.count) * 80)
+    }
+
+    private var staticListView: some View {
+        LazyVStack(spacing: 8) {
+            ForEach(Array(players.enumerated()), id: \.element.id) { index, player in
+                playerRow(player: player, index: index)
+                    .padding(.horizontal, 4)
+                    .background(rowBackground(index: index))
+            }
+        }
+    }
+
+    private func playerRow(player: Player, index: Int) -> some View {
+        ActivePlayerRowView(
+            player: player,
+            isNextToSubOut: isNextToSubOut(index),
+            onTap: { onPlayerTap(player) }
+        )
+    }
+
+    private func rowBackground(index: Int) -> some View {
+        isNextToSubOut(index)
+            ? RoundedRectangle(cornerRadius: 12).fill(Color.appOrange.opacity(0.1))
+            : RoundedRectangle(cornerRadius: 12).fill(Color(uiColor: .secondarySystemBackground))
+    }
 
     private var emptyStateView: some View {
         Text("No active players. Tap a player on the bench to activate.")

--- a/SubTimer/Views/Components/Players/BenchPlayerRowView.swift
+++ b/SubTimer/Views/Components/Players/BenchPlayerRowView.swift
@@ -28,45 +28,54 @@ struct BenchPlayerRowView: View {
 
     private var rowContent: some View {
         HStack {
-            VStack(alignment: .leading, spacing: 4) {
-                HStack {
-                    Text(player.name)
-                        .font(.headline)
-                    if isNextUp && !canActivate {
-                        Image(systemName: "arrow.up.circle.fill")
-                            .foregroundStyle(.green)
-                            .font(.caption)
-                            .accessibilityLabel("Next Up")
-                    }
-                }
-                Text("Total: \(TimeFormatter.format(player.totalPlayTime))")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .monospacedDigit()
-            }
-
+            playerInfo
             Spacer()
-
-            Button(action: onTap) {
-                Image(systemName: "ellipsis.circle")
-                    .font(.title2)
-                    .foregroundStyle(.appPurple)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("More")
-
+            moreButton
             if canActivate {
-                Button(action: onActivate) {
-                    Image(systemName: "plus.circle.fill")
-                        .font(.title2)
-                        .foregroundStyle(.green)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Activate")
+                activateButton
             }
         }
         .padding()
         .cornerRadius(8)
+    }
+
+    private var playerInfo: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(player.name)
+                    .font(.headline)
+                if isNextUp && !canActivate {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .foregroundStyle(.green)
+                        .font(.caption)
+                        .accessibilityLabel("Next Up")
+                }
+            }
+            Text("Total: \(TimeFormatter.format(player.totalPlayTime))")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        }
+    }
+
+    private var moreButton: some View {
+        Button(action: onTap) {
+            Image(systemName: "ellipsis.circle")
+                .font(.title2)
+                .foregroundStyle(.appPurple)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("More")
+    }
+
+    private var activateButton: some View {
+        Button(action: onActivate) {
+            Image(systemName: "plus.circle.fill")
+                .font(.title2)
+                .foregroundStyle(.green)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Activate")
     }
 }
 

--- a/SubTimer/Views/Components/Players/BenchSectionView.swift
+++ b/SubTimer/Views/Components/Players/BenchSectionView.swift
@@ -28,65 +28,14 @@ struct BenchSectionView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            // Header
-            HStack {
-                Label("Bench", systemImage: "person.2")
-                    .font(.title3)
-                    .bold()
-                Spacer()
-                Text("\(players.count)")
-                    .foregroundStyle(.secondary)
-            }
+            headerView
 
-            // Content
             if players.isEmpty {
                 emptyStateView
             } else if onReorder != nil {
-                List {
-                    ForEach(Array(players.enumerated()), id: \.element.id) { index, player in
-                        BenchPlayerRowView(
-                            player: player,
-                            isNextUp: index == 0,
-                            canActivate: canActivate,
-                            onTap: { onPlayerTap(player) },
-                            onActivate: { onActivatePlayer(player) }
-                        )
-                        .listRowInsets(EdgeInsets())
-                        .listRowSeparator(.hidden)
-                        .listRowBackground(
-                            index == 0
-                                ? RoundedRectangle(cornerRadius: 12).fill(Color.green.opacity(0.1))
-                                : RoundedRectangle(cornerRadius: 12).fill(
-                                    Color(uiColor: .secondarySystemBackground)
-                                )
-                        )
-                    }
-                    .onMove(perform: movePlayer)
-                }
-                .listStyle(.plain)
-                .listRowSpacing(8)
-                .environment(\.editMode, .constant(.active))
-                .frame(height: CGFloat(players.count) * 80)
+                reorderableListView
             } else {
-                LazyVStack(spacing: 8) {
-                    ForEach(Array(players.enumerated()), id: \.element.id) { index, player in
-                        BenchPlayerRowView(
-                            player: player,
-                            isNextUp: index == 0,
-                            canActivate: canActivate,
-                            onTap: { onPlayerTap(player) },
-                            onActivate: { onActivatePlayer(player) }
-                        )
-                        .padding(.horizontal, 4)
-                        .background(
-                            index == 0
-                                ? RoundedRectangle(cornerRadius: 12).fill(Color.green.opacity(0.1))
-                                : RoundedRectangle(cornerRadius: 12).fill(
-                                    Color(uiColor: .secondarySystemBackground)
-                                )
-                        )
-                    }
-                }
+                staticListView
             }
         }
     }
@@ -100,6 +49,59 @@ struct BenchSectionView: View {
     }
 
     // MARK: - Helper Views
+
+    private var headerView: some View {
+        HStack {
+            Label("Bench", systemImage: "person.2")
+                .font(.title3)
+                .bold()
+            Spacer()
+            Text("\(players.count)")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var reorderableListView: some View {
+        List {
+            ForEach(Array(players.enumerated()), id: \.element.id) { index, player in
+                playerRow(player: player, index: index)
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(rowBackground(index: index))
+            }
+            .onMove(perform: movePlayer)
+        }
+        .listStyle(.plain)
+        .listRowSpacing(8)
+        .environment(\.editMode, .constant(.active))
+        .frame(height: CGFloat(players.count) * 80)
+    }
+
+    private var staticListView: some View {
+        LazyVStack(spacing: 8) {
+            ForEach(Array(players.enumerated()), id: \.element.id) { index, player in
+                playerRow(player: player, index: index)
+                    .padding(.horizontal, 4)
+                    .background(rowBackground(index: index))
+            }
+        }
+    }
+
+    private func playerRow(player: Player, index: Int) -> some View {
+        BenchPlayerRowView(
+            player: player,
+            isNextUp: index == 0,
+            canActivate: canActivate,
+            onTap: { onPlayerTap(player) },
+            onActivate: { onActivatePlayer(player) }
+        )
+    }
+
+    private func rowBackground(index: Int) -> some View {
+        index == 0
+            ? RoundedRectangle(cornerRadius: 12).fill(Color.green.opacity(0.1))
+            : RoundedRectangle(cornerRadius: 12).fill(Color(uiColor: .secondarySystemBackground))
+    }
 
     private var emptyStateView: some View {
         Text("No players on bench")

--- a/SubTimer/Views/Components/Settings/EditPlayerSheetView.swift
+++ b/SubTimer/Views/Components/Settings/EditPlayerSheetView.swift
@@ -43,44 +43,9 @@ struct EditPlayerSheetView: View {
     var body: some View {
         NavigationStack {
             Form {
-                Section("Player Information") {
-                    TextField("Name", text: $editedName)
-                        .textInputAutocapitalization(.words)
-                }
-
-                Section("Status") {
-                    Picker("Status", selection: $editedStatus) {
-                        Text("On Bench").tag(PlayerStatus.benched)
-                        Text("Currently Playing").tag(PlayerStatus.active)
-                        Text("Temporarily Out").tag(PlayerStatus.temporarilyOut)
-                    }
-                    .pickerStyle(.inline)
-                }
-
-                Section {
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack {
-                            Text("Current Play Duration:")
-                            Spacer()
-                            Text(TimeFormatter.format(player.currentPlayDuration))
-                                .foregroundStyle(.secondary)
-                        }
-                        HStack {
-                            Text("Total Play Time:")
-                            Spacer()
-                            Text(TimeFormatter.format(player.totalPlayTime))
-                                .foregroundStyle(.secondary)
-                        }
-                        HStack {
-                            Text("Created:")
-                            Spacer()
-                            Text(player.createdDate, format: .dateTime.month().day().year())
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                } header: {
-                    Text("Statistics")
-                }
+                nameSection
+                statusSection
+                statisticsSection
             }
             .navigationTitle("Edit Player")
             .navigationBarTitleDisplayMode(.inline)
@@ -97,6 +62,53 @@ struct EditPlayerSheetView: View {
                     .disabled(!isNameValid)
                 }
             }
+        }
+    }
+
+    // MARK: - Form Sections
+
+    private var nameSection: some View {
+        Section("Player Information") {
+            TextField("Name", text: $editedName)
+                .textInputAutocapitalization(.words)
+        }
+    }
+
+    private var statusSection: some View {
+        Section("Status") {
+            Picker("Status", selection: $editedStatus) {
+                Text("On Bench").tag(PlayerStatus.benched)
+                Text("Currently Playing").tag(PlayerStatus.active)
+                Text("Temporarily Out").tag(PlayerStatus.temporarilyOut)
+            }
+            .pickerStyle(.inline)
+        }
+    }
+
+    private var statisticsSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Current Play Duration:")
+                    Spacer()
+                    Text(TimeFormatter.format(player.currentPlayDuration))
+                        .foregroundStyle(.secondary)
+                }
+                HStack {
+                    Text("Total Play Time:")
+                    Spacer()
+                    Text(TimeFormatter.format(player.totalPlayTime))
+                        .foregroundStyle(.secondary)
+                }
+                HStack {
+                    Text("Created:")
+                    Spacer()
+                    Text(player.createdDate, format: .dateTime.month().day().year())
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } header: {
+            Text("Statistics")
         }
     }
 

--- a/SubTimer/Views/TimerView.swift
+++ b/SubTimer/Views/TimerView.swift
@@ -236,61 +236,76 @@ struct TimerView: View {
 
     private var mainTimerView: some View {
         ScrollViewReader { scrollProxy in
-            ScrollView {
-                VStack(spacing: 24) {
-                    timerControlsSection
-                        .id("timerControls")
-                    preferredTimeDisplay
-                        .background(
-                            GeometryReader { geo in
-                                Color.clear.preference(
-                                    key: TimerVisibilityPreferenceKey.self,
-                                    value: geo.frame(in: .named("timerScroll"))
-                                )
-                            }
-                        )
-                    activePlayersSection
-                    benchSection
-                    if !temporarilyOutPlayers.isEmpty {
-                        temporarilyOutSection
+            scrollableContent(scrollProxy: scrollProxy)
+        }
+    }
+
+    private func scrollableContent(scrollProxy: ScrollViewProxy) -> some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                timerControlsSection
+                    .id("timerControls")
+                preferredTimeDisplay
+                    .background(timerVisibilityTracker)
+                activePlayersSection
+                benchSection
+                if !temporarilyOutPlayers.isEmpty {
+                    temporarilyOutSection
+                }
+            }
+            .padding()
+        }
+        .coordinateSpace(name: "timerScroll")
+        .onPreferenceChange(TimerVisibilityPreferenceKey.self, perform: handleTimerVisibilityChange)
+        .safeAreaInset(edge: .top) {
+            compactTimerBar(scrollProxy: scrollProxy)
+        }
+        .safeAreaInset(edge: .bottom) {
+            pinnedSubstituteButton
+                .opacity(showPinnedButton ? 1 : 0)
+                .offset(y: showPinnedButton ? 0 : 40)
+        }
+        .onAppear(perform: animatePinnedButtonIn)
+    }
+
+    private var timerVisibilityTracker: some View {
+        GeometryReader { geo in
+            Color.clear.preference(
+                key: TimerVisibilityPreferenceKey.self,
+                value: geo.frame(in: .named("timerScroll"))
+            )
+        }
+    }
+
+    private func handleTimerVisibilityChange(_ frame: CGRect) {
+        let isVisible = frame.maxY > 0
+        if showCompactTimer != !isVisible {
+            withAnimation(.easeInOut(duration: 0.25)) {
+                showCompactTimer = !isVisible
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func compactTimerBar(scrollProxy: ScrollViewProxy) -> some View {
+        if showCompactTimer {
+            CompactTimerBarView(
+                currentPlayDuration: timerViewModel?.elapsedTime ?? 0,
+                preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
+                onTap: {
+                    withAnimation {
+                        scrollProxy.scrollTo("timerControls", anchor: .top)
                     }
                 }
-                .padding()
-            }
-            .coordinateSpace(name: "timerScroll")
-            .onPreferenceChange(TimerVisibilityPreferenceKey.self) { frame in
-                let isVisible = frame.maxY > 0
-                if showCompactTimer != !isVisible {
-                    withAnimation(.easeInOut(duration: 0.25)) {
-                        showCompactTimer = !isVisible
-                    }
-                }
-            }
-            .safeAreaInset(edge: .top) {
-                if showCompactTimer {
-                    CompactTimerBarView(
-                        currentPlayDuration: timerViewModel?.elapsedTime ?? 0,
-                        preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
-                        onTap: {
-                            withAnimation {
-                                scrollProxy.scrollTo("timerControls", anchor: .top)
-                            }
-                        }
-                    )
-                    .transition(.move(edge: .top).combined(with: .opacity))
-                }
-            }
-            .safeAreaInset(edge: .bottom) {
-                pinnedSubstituteButton
-                    .opacity(showPinnedButton ? 1 : 0)
-                    .offset(y: showPinnedButton ? 0 : 40)
-            }
-            .onAppear {
-                guard !showPinnedButton else { return }
-                withAnimation(.easeOut(duration: 0.45).delay(0.15)) {
-                    showPinnedButton = true
-                }
-            }
+            )
+            .transition(.move(edge: .top).combined(with: .opacity))
+        }
+    }
+
+    private func animatePinnedButtonIn() {
+        guard !showPinnedButton else { return }
+        withAnimation(.easeOut(duration: 0.45).delay(0.15)) {
+            showPinnedButton = true
         }
     }
 
@@ -711,12 +726,11 @@ extension TimerView {
         .modelContainer(for: [Player.self, AppConfiguration.self, Session.self], inMemory: true)
 }
 
-#Preview("Main Timer View") {
-    // Preview providers are compile-time-only and never execute in a shipped
-    // build; the throwing `#Preview` macro overload requires a `@ViewBuilder`
-    // closure, which disallows the explicit `return` below, so `try!` (not
-    // `try?`/do-catch) is the only option that keeps this preview's original
-    // structure intact.
+/// Preview providers are compile-time-only and never execute in a shipped
+/// build, so a failed `ModelContainer` creation here can only mean a bug in
+/// this preview's setup - `try!` surfaces that immediately instead of
+/// silently producing a broken preview.
+private func makeMainTimerPreviewContainer() -> ModelContainer {
     // swiftlint:disable:next force_try
     let container = try! ModelContainer(
         for: Player.self, AppConfiguration.self, Session.self,
@@ -763,6 +777,10 @@ extension TimerView {
     context.insert(player5)
     context.insert(player6)
 
-    return TimerView()
-        .modelContainer(container)
+    return container
+}
+
+#Preview("Main Timer View") {
+    TimerView()
+        .modelContainer(makeMainTimerPreviewContainer())
 }


### PR DESCRIPTION
## Summary

Extracts the 12 over-long inline SwiftUI closures flagged by SwiftLint's `closure_body_length` rule into named computed properties/methods, across the 7 files named in #70:

- `ActiveBenchLiveActivity.swift` (4)
- `SubTimerApp.swift` (1)
- `ActivePlayersSectionView.swift` (1)
- `BenchPlayerRowView.swift` (1)
- `BenchSectionView.swift` (1)
- `EditPlayerSheetView.swift` (2)
- `TimerView.swift` (2)

**Note on scope:** `closure_body_length` is an opt-in SwiftLint rule and wasn't actually enabled in `.swiftlint.yml` before this PR — which is why `swiftlint lint --strict` reported 0 violations of it even though #70 described 12 flagged closures. This PR enables the rule (last commit) once all 12 sites are extracted, so every commit in between keeps CI green under the *previous* lint config, and the final commit turns the rule on with a clean result.

Each extraction follows the existing per-file convention for decomposing large SwiftUI bodies (e.g. the pre-existing `emptyStateView` helper-view pattern), rather than inventing new idioms. No behavior change.

## Commits

Eight small, independently reviewable commits: one per file for the extractions, plus a final commit enabling `closure_body_length`.

## Verification

- `swiftlint lint --strict`: 0 violations across all 48 files
- Full build succeeds, including the `ActiveBenchExtension` widget/Live Activity target
- `SubTimerTests`: 58/58 unit tests pass
- `SubTimerUITests`: all suites pass (`PlayerComponentsUITests`, `SubTimerUITests`, `SubTimerUITestsLaunchTests`, `TimerViewUITests`, `SettingsViewUITests`)

Closes #70