### PR TITLE
Optional-safety and visibility cleanup

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -46,7 +46,9 @@ opt_in_rules:
   - explicit_enum_raw_value
   - fallthrough
   - first_where
+  - force_unwrapping
   - identical_operands
+  - implicitly_unwrapped_optional
   - indentation_width
   - joined_default_parameter
   - last_where
@@ -61,6 +63,7 @@ opt_in_rules:
   - redundant_type_annotation
   - sorted_first_last
   - sorted_imports
+  - strict_fileprivate
   - toggle_bool
   - unavailable_function
   - unneeded_parentheses_in_closure_argument

--- a/ActiveBench/ActiveBenchLiveActivity.swift
+++ b/ActiveBench/ActiveBenchLiveActivity.swift
@@ -225,15 +225,23 @@ struct ActiveBenchLiveActivity: Widget {
 }
 
 // MARK: - Previews
+//
+// The preview sample data below lives on `ActiveBenchLiveActivity` (rather
+// than as extensions on `ActiveBenchAttributes`/`ContentState`, as a
+// `fileprivate` member would suggest) so it can be `private` and still be
+// reachable from the `#Preview` macros: those macros expand into
+// declarations nested inside the `extension ActiveBenchLiveActivity` block
+// below, which — being another extension of the *same* type in this file —
+// has access to `private` members declared in the first one. A member
+// `private` to `ActiveBenchAttributes` or `ContentState` would not be
+// visible from that expansion, since it's a different type.
 
-extension ActiveBenchAttributes {
-    fileprivate static var preview: ActiveBenchAttributes {
+extension ActiveBenchLiveActivity {
+    private static var previewAttributes: ActiveBenchAttributes {
         ActiveBenchAttributes(sessionName: "Practice Session")
     }
-}
 
-extension ActiveBenchAttributes.ContentState {
-    fileprivate static var running: ActiveBenchAttributes.ContentState {
+    private static var runningState: ActiveBenchAttributes.ContentState {
         ActiveBenchAttributes.ContentState(
             isRunning: true,
             timerStartDate: Date().addingTimeInterval(-120),
@@ -246,7 +254,7 @@ extension ActiveBenchAttributes.ContentState {
         )
     }
 
-    fileprivate static var paused: ActiveBenchAttributes.ContentState {
+    private static var pausedState: ActiveBenchAttributes.ContentState {
         ActiveBenchAttributes.ContentState(
             isRunning: false,
             timerStartDate: Date(),
@@ -259,7 +267,7 @@ extension ActiveBenchAttributes.ContentState {
         )
     }
 
-    fileprivate static var overtime: ActiveBenchAttributes.ContentState {
+    private static var overtimeState: ActiveBenchAttributes.ContentState {
         ActiveBenchAttributes.ContentState(
             isRunning: true,
             timerStartDate: Date().addingTimeInterval(-240),
@@ -273,34 +281,36 @@ extension ActiveBenchAttributes.ContentState {
     }
 }
 
-#Preview("Notification", as: .content, using: ActiveBenchAttributes.preview) {
-    ActiveBenchLiveActivity()
-} contentStates: {
-    ActiveBenchAttributes.ContentState.running
-    ActiveBenchAttributes.ContentState.paused
-    ActiveBenchAttributes.ContentState.overtime
-}
+extension ActiveBenchLiveActivity {
+    #Preview("Notification", as: .content, using: previewAttributes) {
+        ActiveBenchLiveActivity()
+    } contentStates: {
+        runningState
+        pausedState
+        overtimeState
+    }
 
-#Preview("Dynamic Island Expanded", as: .dynamicIsland(.expanded), using: ActiveBenchAttributes.preview) {
-    ActiveBenchLiveActivity()
-} contentStates: {
-    ActiveBenchAttributes.ContentState.running
-    ActiveBenchAttributes.ContentState.paused
-    ActiveBenchAttributes.ContentState.overtime
-}
+    #Preview("Dynamic Island Expanded", as: .dynamicIsland(.expanded), using: previewAttributes) {
+        ActiveBenchLiveActivity()
+    } contentStates: {
+        runningState
+        pausedState
+        overtimeState
+    }
 
-#Preview("Dynamic Island Compact", as: .dynamicIsland(.compact), using: ActiveBenchAttributes.preview) {
-    ActiveBenchLiveActivity()
-} contentStates: {
-    ActiveBenchAttributes.ContentState.running
-    ActiveBenchAttributes.ContentState.paused
-    ActiveBenchAttributes.ContentState.overtime
-}
+    #Preview("Dynamic Island Compact", as: .dynamicIsland(.compact), using: previewAttributes) {
+        ActiveBenchLiveActivity()
+    } contentStates: {
+        runningState
+        pausedState
+        overtimeState
+    }
 
-#Preview("Dynamic Island Minimal", as: .dynamicIsland(.minimal), using: ActiveBenchAttributes.preview) {
-    ActiveBenchLiveActivity()
-} contentStates: {
-    ActiveBenchAttributes.ContentState.running
-    ActiveBenchAttributes.ContentState.paused
-    ActiveBenchAttributes.ContentState.overtime
+    #Preview("Dynamic Island Minimal", as: .dynamicIsland(.minimal), using: previewAttributes) {
+        ActiveBenchLiveActivity()
+    } contentStates: {
+        runningState
+        pausedState
+        overtimeState
+    }
 }

--- a/SubTimer/ViewModels/TimerViewModel.swift
+++ b/SubTimer/ViewModels/TimerViewModel.swift
@@ -36,13 +36,14 @@ class TimerViewModel {
         timerStartDate = Date()
         elapsedTime = computeElapsedTime()
 
-        displayTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+        let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             guard let self else { return }
             self.elapsedTime = self.computeElapsedTime()
             self.onTimerTick?()
         }
+        displayTimer = timer
         // ensures timer keeps counting even when scrolling
-        RunLoop.current.add(displayTimer!, forMode: .common)
+        RunLoop.current.add(timer, forMode: .common)
     }
 
     func pauseTimer() {

--- a/SubTimerUITests/PlayerComponentsUITests.swift
+++ b/SubTimerUITests/PlayerComponentsUITests.swift
@@ -21,6 +21,11 @@
 import XCTest
 
 final class PlayerComponentsUITests: XCTestCase {
+    // Standard XCTest UI-test scaffolding: `app` is always assigned in
+    // `setUpWithError` before any test method runs, so the implicit unwrap
+    // never actually fires. Rewriting this to an `Optional` with unwrapping
+    // at every use site would only add noise to idiomatic test boilerplate.
+    // swiftlint:disable:next implicitly_unwrapped_optional
     var app: XCUIApplication!
 
     override func setUpWithError() throws {

--- a/SubTimerUITests/SettingsViewUITests.swift
+++ b/SubTimerUITests/SettingsViewUITests.swift
@@ -46,6 +46,11 @@ final class SettingsViewUITests: XCTestCase {
     /// drift apart.
     private static let playerRowIdentifier = "settings.player.row"
 
+    // Standard XCTest UI-test scaffolding: `app` is always assigned in
+    // `setUpWithError` before any test method runs, so the implicit unwrap
+    // never actually fires. Rewriting this to an `Optional` with unwrapping
+    // at every use site would only add noise to idiomatic test boilerplate.
+    // swiftlint:disable:next implicitly_unwrapped_optional
     var app: XCUIApplication!
 
     override func setUpWithError() throws {

--- a/SubTimerUITests/TimerViewUITests.swift
+++ b/SubTimerUITests/TimerViewUITests.swift
@@ -26,6 +26,11 @@ import XCTest
 
 // swiftlint:disable:next type_body_length
 final class TimerViewUITests: XCTestCase {
+    // Standard XCTest UI-test scaffolding: `app` is always assigned in
+    // `setUpWithError` before any test method runs, so the implicit unwrap
+    // never actually fires. Rewriting this to an `Optional` with unwrapping
+    // at every use site would only add noise to idiomatic test boilerplate.
+    // swiftlint:disable:next implicitly_unwrapped_optional
     var app: XCUIApplication!
 
     override func setUpWithError() throws {


### PR DESCRIPTION
## Summary

Closes #69.

Resolves three related SwiftLint follow-up findings from the baseline established in #48 / PR #66. All three rules (`force_unwrapping`, `strict_fileprivate`, `implicitly_unwrapped_optional`) are opt-in and were not previously enabled in `.swiftlint.yml`; enabling them is part of satisfying the "zero violations for these rules" acceptance criterion.

- **`force_unwrapping`** — `TimerViewModel.swift:45`'s `RunLoop.current.add(displayTimer!, ...)` is replaced by binding the repeating `Timer` to a local `let` before assigning it to the optional `displayTimer` property. No behavior change; the existing `TimerViewModelTests` suite (including the tick/pause/reset tests that exercise this exact code path) still passes.
- **`strict_fileprivate`** — the 4 `fileprivate` preview-data members in `ActiveBenchLiveActivity.swift` are now `private`. I confirmed by actually compiling (`xcodebuild build -scheme ActiveBenchExtension`) that plain `private` extension members of `ActiveBenchAttributes`/`ContentState` are **not** reachable from the top-level `#Preview` macro call sites (Swift's access rule only extends `private` to *other extensions of the same type* in the same file, not to arbitrary file-scope code) — so `private` alone would not compile in the original structure. The fix relocates the sample preview data onto `ActiveBenchLiveActivity` itself as `private static` members, and nests the four `#Preview` macro calls inside an `extension ActiveBenchLiveActivity { ... }` block, which — being another extension of the *same* type — has the access it needs. Preview content (session name, running/paused/overtime states) is unchanged, just relocated.
- **`implicitly_unwrapped_optional`** — the 3 `var app: XCUIApplication!` declarations in `PlayerComponentsUITests.swift`, `TimerViewUITests.swift`, and `SettingsViewUITests.swift` are Apple's own standard XCTest UI-test boilerplate; `app` is always assigned in `setUpWithError` before any test runs. Each now carries a documented `// swiftlint:disable:next implicitly_unwrapped_optional` with an inline comment explaining why, matching the established pattern from #48 / PR #66 rather than rewriting idiomatic test scaffolding.

## Verification

- `swiftlint lint --strict` → 0 violations, 0 serious, 48 files (with the 3 new opt-in rules enabled).
- `xcodebuild test` (SubTimerTests): all 58 unit tests pass, including the timer tick/pause/reset tests covering the `TimerViewModel` change.
- `xcodebuild test` (SubTimerUITests): 24/25 pass; the one failure (`PlayerComponentsUITests.testPlayerRowStatusTransitionFlow`) is the pre-existing timing flake already documented in PR #66's own verification notes — confirmed by re-running it standalone, where it passed.
- `xcodebuild build -scheme ActiveBenchExtension` confirms the `ActiveBenchLiveActivity.swift` restructuring actually compiles (and that plain `private` in the *original* structure would not have).

## Acceptance criteria

- [x] The force-unwrap in `TimerViewModel.swift` is replaced with safe handling
- [x] The 4 `fileprivate` members in `ActiveBenchLiveActivity.swift` have a correct, deliberate access level
- [x] The 3 `XCUIApplication!` declarations are excluded with an inline comment explaining why (per the established pattern from #48 / PR #66)
- [x] `swiftlint lint --strict` shows zero violations for `force_unwrapping`, `strict_fileprivate`, and `implicitly_unwrapped_optional`
- [x] Full test suite passes