### PR TITLE
Add Team/RosterMembership/Game/Stint schema (dormant, CloudKit-verified)

### DIFF
--- a/SubTimer/Models/AppConfiguration.swift
+++ b/SubTimer/Models/AppConfiguration.swift
@@ -10,15 +10,18 @@ import SwiftData
 
 @Model
 final class AppConfiguration {
-    var id: UUID
-    var preferredPlayTimeSeconds: Int
-    var activePlayersCount: Int
-    var lastModifiedDate: Date
+    static let defaultPreferredPlayTimeSeconds = 180 // Default 3:00 minutes
+    static let defaultActivePlayersCount = 4
+
+    var id = UUID()
+    var preferredPlayTimeSeconds = AppConfiguration.defaultPreferredPlayTimeSeconds
+    var activePlayersCount = AppConfiguration.defaultActivePlayersCount
+    var lastModifiedDate = Date()
 
     init(
         id: UUID = UUID(),
-        preferredPlayTimeSeconds: Int = 180, // Default 3:00 minutes
-        activePlayersCount: Int = 4,
+        preferredPlayTimeSeconds: Int = AppConfiguration.defaultPreferredPlayTimeSeconds,
+        activePlayersCount: Int = AppConfiguration.defaultActivePlayersCount,
         lastModifiedDate: Date = Date()
     ) {
         self.id = id

--- a/SubTimer/Models/Game.swift
+++ b/SubTimer/Models/Game.swift
@@ -1,0 +1,59 @@
+//
+//  Game.swift
+//  SubTimer
+//
+//  Created by SubTimer on 8/6/26.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+final class Game {
+    static let defaultSubstitutionCount = 0
+    static let defaultPreferredPlayTimeSeconds = 180
+    static let defaultActivePlayersCount = 4
+    static let defaultActiveOrder: [UUID] = []
+    static let defaultBenchOrder: [UUID] = []
+    static let defaultTemporarilyOut: Set<UUID> = []
+
+    var id = UUID()
+    var startDate = Date()
+    var endDate: Date?
+    var substitutionCount = Game.defaultSubstitutionCount
+    var preferredPlayTimeSeconds = Game.defaultPreferredPlayTimeSeconds
+    var activePlayersCount = Game.defaultActivePlayersCount
+    var activeOrder = Game.defaultActiveOrder
+    var benchOrder = Game.defaultBenchOrder
+    var temporarilyOut = Game.defaultTemporarilyOut
+
+    @Relationship(deleteRule: .nullify)
+    var team: Team?
+
+    @Relationship(deleteRule: .nullify, inverse: \Stint.game)
+    var stints: [Stint]?
+
+    init(
+        id: UUID = UUID(),
+        startDate: Date = Date(),
+        endDate: Date? = nil,
+        substitutionCount: Int = Game.defaultSubstitutionCount,
+        preferredPlayTimeSeconds: Int = Game.defaultPreferredPlayTimeSeconds,
+        activePlayersCount: Int = Game.defaultActivePlayersCount,
+        activeOrder: [UUID] = Game.defaultActiveOrder,
+        benchOrder: [UUID] = Game.defaultBenchOrder,
+        temporarilyOut: Set<UUID> = Game.defaultTemporarilyOut,
+        team: Team? = nil
+    ) {
+        self.id = id
+        self.startDate = startDate
+        self.endDate = endDate
+        self.substitutionCount = substitutionCount
+        self.preferredPlayTimeSeconds = preferredPlayTimeSeconds
+        self.activePlayersCount = activePlayersCount
+        self.activeOrder = activeOrder
+        self.benchOrder = benchOrder
+        self.temporarilyOut = temporarilyOut
+        self.team = team
+    }
+}

--- a/SubTimer/Models/OrderManager.swift
+++ b/SubTimer/Models/OrderManager.swift
@@ -15,16 +15,18 @@ enum PlayerOrderRole: String, Codable {
 
 @Model
 final class OrderManager {
-    var id: UUID
-    var role: PlayerOrderRole
-    var playerOrder: [UUID]
-    var createdDate: Date
-    var updatedDate: Date
+    static let defaultPlayerOrder: [UUID] = []
+
+    var id = UUID()
+    var role = PlayerOrderRole.bench
+    var playerOrder = OrderManager.defaultPlayerOrder
+    var createdDate = Date()
+    var updatedDate = Date()
 
     init(
         role: PlayerOrderRole,
         id: UUID = UUID(),
-        playerOrder: [UUID] = [],
+        playerOrder: [UUID] = OrderManager.defaultPlayerOrder,
         createdDate: Date = Date(),
         updatedDate: Date = Date()
     ) {

--- a/SubTimer/Models/Player.swift
+++ b/SubTimer/Models/Player.swift
@@ -10,23 +10,37 @@ import SwiftData
 
 @Model
 final class Player {
-    var id: UUID
-    var name: String
-    var createdDate: Date
-    var currentPlayDuration: TimeInterval
-    var totalPlayTime: TimeInterval
-    var status: PlayerStatus
-    var sortOrder: Int
-    var activatedAtDate: Date
+    static let defaultCurrentPlayDuration: TimeInterval = 0
+    static let defaultTotalPlayTime: TimeInterval = 0
+    static let defaultStatus: PlayerStatus = .benched
+    static let defaultSortOrder = 0
+
+    var id = UUID()
+    var name: String = ""
+    var createdDate = Date()
+    var currentPlayDuration = Player.defaultCurrentPlayDuration
+    var totalPlayTime = Player.defaultTotalPlayTime
+    var status = Player.defaultStatus
+    var sortOrder = Player.defaultSortOrder
+    var activatedAtDate = Date()
+
+    // Dormant, additive relationships from #57 — nothing reads or writes
+    // these yet. Required as CloudKit-compatible inverses for
+    // `RosterMembership.player` / `Stint.player` (see #55).
+    @Relationship(deleteRule: .nullify, inverse: \RosterMembership.player)
+    var rosterMemberships: [RosterMembership]?
+
+    @Relationship(deleteRule: .nullify, inverse: \Stint.player)
+    var stints: [Stint]?
 
     init(
         id: UUID = UUID(),
         name: String,
         createdDate: Date = Date(),
-        currentPlayDuration: TimeInterval = 0,
-        totalPlayTime: TimeInterval = 0,
-        status: PlayerStatus = .benched,
-        sortOrder: Int = 0,
+        currentPlayDuration: TimeInterval = Player.defaultCurrentPlayDuration,
+        totalPlayTime: TimeInterval = Player.defaultTotalPlayTime,
+        status: PlayerStatus = Player.defaultStatus,
+        sortOrder: Int = Player.defaultSortOrder,
         activatedAtDate: Date = Date()
     ) {
         self.id = id

--- a/SubTimer/Models/RosterMembership.swift
+++ b/SubTimer/Models/RosterMembership.swift
@@ -1,0 +1,33 @@
+//
+//  RosterMembership.swift
+//  SubTimer
+//
+//  Created by SubTimer on 8/6/26.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+final class RosterMembership {
+    var id = UUID()
+    var position: String?
+
+    @Relationship(deleteRule: .nullify)
+    var player: Player?
+
+    @Relationship(deleteRule: .nullify)
+    var team: Team?
+
+    init(
+        id: UUID = UUID(),
+        position: String? = nil,
+        player: Player? = nil,
+        team: Team? = nil
+    ) {
+        self.id = id
+        self.position = position
+        self.player = player
+        self.team = team
+    }
+}

--- a/SubTimer/Models/Session.swift
+++ b/SubTimer/Models/Session.swift
@@ -10,24 +10,30 @@ import SwiftData
 
 @Model
 final class Session {
-    var id: UUID
-    var startDate: Date
+    static let defaultDuration: TimeInterval = 0
+    static let defaultSubstitutionCount = 0
+    static let defaultPreferredPlayTimeSeconds = 180 // Default 3:00 minutes
+    static let defaultActivePlayersCount = 4
+    static let defaultPlayerNames: [String] = []
+
+    var id = UUID()
+    var startDate = Date()
     var endDate: Date?
-    var duration: TimeInterval
-    var substitutionCount: Int
-    var preferredPlayTimeSeconds: Int
-    var activePlayersCount: Int
-    var playerNames: [String]
+    var duration = Session.defaultDuration
+    var substitutionCount = Session.defaultSubstitutionCount
+    var preferredPlayTimeSeconds = Session.defaultPreferredPlayTimeSeconds
+    var activePlayersCount = Session.defaultActivePlayersCount
+    var playerNames = Session.defaultPlayerNames
 
     init(
         id: UUID = UUID(),
         startDate: Date = Date(),
         endDate: Date? = nil,
-        duration: TimeInterval = 0,
-        substitutionCount: Int = 0,
-        preferredPlayTimeSeconds: Int = 180,
-        activePlayersCount: Int = 4,
-        playerNames: [String] = []
+        duration: TimeInterval = Session.defaultDuration,
+        substitutionCount: Int = Session.defaultSubstitutionCount,
+        preferredPlayTimeSeconds: Int = Session.defaultPreferredPlayTimeSeconds,
+        activePlayersCount: Int = Session.defaultActivePlayersCount,
+        playerNames: [String] = Session.defaultPlayerNames
     ) {
         self.id = id
         self.startDate = startDate

--- a/SubTimer/Models/Stint.swift
+++ b/SubTimer/Models/Stint.swift
@@ -1,0 +1,39 @@
+//
+//  Stint.swift
+//  SubTimer
+//
+//  Created by SubTimer on 8/6/26.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+final class Stint {
+    var id = UUID()
+    var startDate = Date()
+    var endDate: Date?
+    var position: String?
+
+    @Relationship(deleteRule: .nullify)
+    var player: Player?
+
+    @Relationship(deleteRule: .nullify)
+    var game: Game?
+
+    init(
+        id: UUID = UUID(),
+        startDate: Date = Date(),
+        endDate: Date? = nil,
+        position: String? = nil,
+        player: Player? = nil,
+        game: Game? = nil
+    ) {
+        self.id = id
+        self.startDate = startDate
+        self.endDate = endDate
+        self.position = position
+        self.player = player
+        self.game = game
+    }
+}

--- a/SubTimer/Models/Team.swift
+++ b/SubTimer/Models/Team.swift
@@ -1,0 +1,41 @@
+//
+//  Team.swift
+//  SubTimer
+//
+//  Created by SubTimer on 8/6/26.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+final class Team {
+    static let defaultPreferredPlayTimeSeconds = 180
+    static let defaultActivePlayersCount = 4
+
+    var id = UUID()
+    var name: String = ""
+    var sport: String = ""
+    var preferredPlayTimeSeconds = Team.defaultPreferredPlayTimeSeconds
+    var activePlayersCount = Team.defaultActivePlayersCount
+
+    @Relationship(deleteRule: .nullify, inverse: \RosterMembership.team)
+    var rosterMemberships: [RosterMembership]?
+
+    @Relationship(deleteRule: .nullify, inverse: \Game.team)
+    var games: [Game]?
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        sport: String,
+        preferredPlayTimeSeconds: Int = Team.defaultPreferredPlayTimeSeconds,
+        activePlayersCount: Int = Team.defaultActivePlayersCount
+    ) {
+        self.id = id
+        self.name = name
+        self.sport = sport
+        self.preferredPlayTimeSeconds = preferredPlayTimeSeconds
+        self.activePlayersCount = activePlayersCount
+    }
+}

--- a/SubTimer/SubTimerApp.swift
+++ b/SubTimer/SubTimerApp.swift
@@ -26,7 +26,11 @@ struct SubTimerApp: App {
             Player.self,
             AppConfiguration.self,
             Session.self,
-            OrderManager.self
+            OrderManager.self,
+            Team.self,
+            RosterMembership.self,
+            Game.self,
+            Stint.self
         ])
 
         // Use in-memory storage for UI testing

--- a/SubTimerTests/CloudKitSchemaTests.swift
+++ b/SubTimerTests/CloudKitSchemaTests.swift
@@ -1,0 +1,48 @@
+//
+//  CloudKitSchemaTests.swift
+//  SubTimerTests
+//
+//  Created by SubTimer on 8/6/26.
+//
+
+import Foundation
+@testable import SubTimer
+import SwiftData
+import Testing
+
+/// Verifies the full schema — the existing `Player`/`AppConfiguration`/
+/// `Session`/`OrderManager` types plus the new, dormant
+/// `Team`/`RosterMembership`/`Game`/`Stint` types from #57 — is
+/// CloudKit-compatible: no `@Attribute(.unique)`, no non-optional
+/// relationships, no unsupported value types.
+///
+/// This uses an in-memory, dev-only `ModelConfiguration` purely to exercise
+/// SwiftData's CloudKit-compatibility validation at container-init time.
+/// No real CloudKit container is contacted, no data is synced, and this is
+/// not the app's shipped/production configuration — see
+/// docs/adr/0001-local-only-persistence-no-cloudkit.md, which this test
+/// does not change.
+struct CloudKitSchemaTests {
+    @Test func fullSchemaInitializesUnderCloudKitConfiguration() throws {
+        let schema = Schema([
+            Player.self,
+            AppConfiguration.self,
+            Session.self,
+            OrderManager.self,
+            Team.self,
+            RosterMembership.self,
+            Game.self,
+            Stint.self
+        ])
+
+        let configuration = ModelConfiguration(
+            schema: schema,
+            isStoredInMemoryOnly: true,
+            cloudKitDatabase: .private("iCloud.com.synbydesign.SubTimer")
+        )
+
+        #expect(throws: Never.self) {
+            _ = try ModelContainer(for: schema, configurations: [configuration])
+        }
+    }
+}

--- a/SubTimerTests/CloudKitSchemaTests.swift
+++ b/SubTimerTests/CloudKitSchemaTests.swift
@@ -12,17 +12,44 @@ import Testing
 
 /// Verifies the full schema — the existing `Player`/`AppConfiguration`/
 /// `Session`/`OrderManager` types plus the new, dormant
-/// `Team`/`RosterMembership`/`Game`/`Stint` types from #57 — is
-/// CloudKit-compatible: no `@Attribute(.unique)`, no non-optional
-/// relationships, no unsupported value types.
+/// `Team`/`RosterMembership`/`Game`/`Stint` types from #57 — satisfies the
+/// CloudKit *model-shape* rules: no `@Attribute(.unique)`, every relationship
+/// optional and inverse-paired, every attribute optional or carrying a
+/// default.
 ///
-/// This uses an in-memory, dev-only `ModelConfiguration` purely to exercise
-/// SwiftData's CloudKit-compatibility validation at container-init time.
-/// No real CloudKit container is contacted, no data is synced, and this is
-/// not the app's shipped/production configuration — see
-/// docs/adr/0001-local-only-persistence-no-cloudkit.md, which this test
-/// does not change.
+/// Scope, precisely: setting `cloudKitDatabase` to anything other than `.none`
+/// makes `ModelContainer.init` run SwiftData's synchronous CloudKit model
+/// validator, which throws on any of the above. That is the whole of what this
+/// test covers, and it's the technique Apple engineering recommends for it
+/// (Developer Forums 751617: "enable CloudKit temporarily to run the validator
+/// against your model. If the ModelContainer initializes the model is
+/// compatible").
+///
+/// What it deliberately does *not* cover: whether iCloud sync actually works.
+/// Container provisioning and mirroring setup happen asynchronously in
+/// `NSCloudKitMirroringDelegate` after `init` returns and surface only as log
+/// output — never as a thrown error — so no test shaped like this one can
+/// observe them. Proving real sync needs
+/// `NSPersistentCloudKitContainer.initializeCloudKitSchema()` against a
+/// provisioned container with a signed-in account, which is not CI-friendly.
+/// Nothing here contacts CloudKit, syncs data, or changes the app's shipped
+/// local-only configuration (see
+/// docs/adr/0001-local-only-persistence-no-cloudkit.md).
+///
+/// See `CloudKitSchemaNegativeControlTests` for the proof that the assertion
+/// below can actually fail.
 struct CloudKitSchemaTests {
+    /// The app's real iCloud container identifier.
+    ///
+    /// Inert in these tests: the validator above rejects or accepts a schema on
+    /// shape alone and never resolves this string, contacts CloudKit, or
+    /// consults entitlements — `SubTimer.entitlements` doesn't even list it
+    /// (`com.apple.developer.icloud-container-identifiers` is an empty array),
+    /// yet validation still runs. It's spelled out in full rather than
+    /// environment-configurable so that if real sync is ever enabled, these
+    /// tests already pin the container the app will ship with.
+    static let cloudKitContainerIdentifier = "iCloud.com.synbydesign.SubTimer"
+
     @Test func fullSchemaInitializesUnderCloudKitConfiguration() throws {
         let schema = Schema([
             Player.self,
@@ -38,11 +65,121 @@ struct CloudKitSchemaTests {
         let configuration = ModelConfiguration(
             schema: schema,
             isStoredInMemoryOnly: true,
-            cloudKitDatabase: .private("iCloud.com.synbydesign.SubTimer")
+            cloudKitDatabase: .private(Self.cloudKitContainerIdentifier)
         )
 
         #expect(throws: Never.self) {
             _ = try ModelContainer(for: schema, configurations: [configuration])
         }
     }
+}
+
+// MARK: - Negative control
+
+/// Proves `CloudKitSchemaTests` has teeth.
+///
+/// A passing `#expect(throws: Never.self)` is only meaningful if the same
+/// assertion would *fail* on a CloudKit-incompatible schema. Nothing in that
+/// test demonstrates it can: if `cloudKitDatabase` were ever switched to
+/// `.none` — or if SwiftData stopped validating for in-memory stores — it would
+/// keep passing while checking nothing whatsoever, silently.
+///
+/// Each probe below violates exactly one CloudKit rule and asserts container
+/// init throws under the CloudKit configuration **and** succeeds under a
+/// local-only one. The second half is what makes it a control rather than a
+/// coincidence: it attributes the rejection to CloudKit validation
+/// specifically, instead of to some unrelated defect in the throwaway model.
+///
+/// All three violations surface as a catchable
+/// `SwiftDataError._Error.loadIssueModelContainer`. Note that this validation
+/// has regressed before — it escaped as an uncatchable trap rather than a
+/// throw on iOS 17.4 (Apple Feedback FB13694972) — so a crash here, rather
+/// than a clean failure, is itself a meaningful signal.
+struct CloudKitSchemaNegativeControlTests {
+    private static func makeContainer(
+        for schema: Schema,
+        cloudKitDatabase: ModelConfiguration.CloudKitDatabase
+    ) throws -> ModelContainer {
+        let configuration = ModelConfiguration(
+            schema: schema,
+            isStoredInMemoryOnly: true,
+            cloudKitDatabase: cloudKitDatabase
+        )
+        return try ModelContainer(for: schema, configurations: [configuration])
+    }
+
+    private static func expectRejectedOnlyByCloudKit(
+        _ schema: Schema,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+        #expect(throws: (any Error).self, sourceLocation: sourceLocation) {
+            _ = try makeContainer(
+                for: schema,
+                cloudKitDatabase: .private(CloudKitSchemaTests.cloudKitContainerIdentifier)
+            )
+        }
+
+        #expect(throws: Never.self, sourceLocation: sourceLocation) {
+            _ = try makeContainer(for: schema, cloudKitDatabase: .none)
+        }
+    }
+
+    @Test func uniqueConstraintIsRejected() {
+        Self.expectRejectedOnlyByCloudKit(Schema([UniqueConstrainedProbe.self]))
+    }
+
+    @Test func nonOptionalAttributeWithoutDefaultIsRejected() {
+        Self.expectRejectedOnlyByCloudKit(Schema([NonOptionalAttributeProbe.self]))
+    }
+
+    @Test func nonOptionalRelationshipIsRejected() {
+        Self.expectRejectedOnlyByCloudKit(
+            Schema([NonOptionalRelationshipParentProbe.self, NonOptionalRelationshipChildProbe.self])
+        )
+    }
+}
+
+// MARK: - Deliberately CloudKit-incompatible probe models
+//
+// These exist only to be rejected by the negative control above. They are
+// never added to the app's schema — see `SubTimerApp.makeModelContainer()` for
+// the real one.
+
+/// Violates "CloudKit integration does not support unique constraints".
+@Model
+final class UniqueConstrainedProbe {
+    @Attribute(.unique) var code: String = ""
+
+    init(code: String = "") {
+        self.code = code
+    }
+}
+
+/// Violates "CloudKit integration requires that all attributes be optional, or
+/// have a default value set".
+@Model
+final class NonOptionalAttributeProbe {
+    var requiredValue: String
+
+    init(requiredValue: String) {
+        self.requiredValue = requiredValue
+    }
+}
+
+/// Violates "CloudKit integration requires that all relationships be optional".
+@Model
+final class NonOptionalRelationshipChildProbe {
+    var parent: NonOptionalRelationshipParentProbe
+
+    init(parent: NonOptionalRelationshipParentProbe) {
+        self.parent = parent
+    }
+}
+
+@Model
+final class NonOptionalRelationshipParentProbe {
+    @Relationship(deleteRule: .cascade, inverse: \NonOptionalRelationshipChildProbe.parent)
+    var children: [NonOptionalRelationshipChildProbe] = []
+
+    init() {}
 }

--- a/SubTimerTests/GameTests.swift
+++ b/SubTimerTests/GameTests.swift
@@ -1,0 +1,45 @@
+//
+//  GameTests.swift
+//  SubTimerTests
+//
+//  Created by SubTimer on 8/6/26.
+//
+
+import Foundation
+@testable import SubTimer
+import SwiftData
+import Testing
+
+struct GameTests {
+    @Test func gameInitialization() {
+        let game = Game()
+
+        #expect(game.endDate == nil)
+        #expect(game.substitutionCount == 0)
+        #expect(game.preferredPlayTimeSeconds == 180)
+        #expect(game.activePlayersCount == 4)
+        #expect(game.activeOrder.isEmpty)
+        #expect(game.benchOrder.isEmpty)
+        #expect(game.temporarilyOut.isEmpty)
+        #expect(game.team == nil)
+        #expect(game.stints == nil)
+    }
+
+    @Test func gameOrderTracking() {
+        let id1 = UUID()
+        let id2 = UUID()
+        let id3 = UUID()
+        let game = Game(activeOrder: [id1, id2], benchOrder: [id3], temporarilyOut: [id2])
+
+        #expect(game.activeOrder == [id1, id2])
+        #expect(game.benchOrder == [id3])
+        #expect(game.temporarilyOut == [id2])
+    }
+
+    @Test func gameTeamAssociation() {
+        let team = Team(name: "Warriors", sport: "Soccer")
+        let game = Game(team: team)
+
+        #expect(game.team === team)
+    }
+}

--- a/SubTimerTests/RosterMembershipTests.swift
+++ b/SubTimerTests/RosterMembershipTests.swift
@@ -1,0 +1,31 @@
+//
+//  RosterMembershipTests.swift
+//  SubTimerTests
+//
+//  Created by SubTimer on 8/6/26.
+//
+
+import Foundation
+@testable import SubTimer
+import SwiftData
+import Testing
+
+struct RosterMembershipTests {
+    @Test func rosterMembershipInitialization() {
+        let membership = RosterMembership()
+
+        #expect(membership.position == nil)
+        #expect(membership.player == nil)
+        #expect(membership.team == nil)
+    }
+
+    @Test func rosterMembershipWithPlayerAndTeam() {
+        let player = Player(name: "Alex")
+        let team = Team(name: "Warriors", sport: "Soccer")
+        let membership = RosterMembership(position: "Forward", player: player, team: team)
+
+        #expect(membership.position == "Forward")
+        #expect(membership.player === player)
+        #expect(membership.team === team)
+    }
+}

--- a/SubTimerTests/StintTests.swift
+++ b/SubTimerTests/StintTests.swift
@@ -1,0 +1,32 @@
+//
+//  StintTests.swift
+//  SubTimerTests
+//
+//  Created by SubTimer on 8/6/26.
+//
+
+import Foundation
+@testable import SubTimer
+import SwiftData
+import Testing
+
+struct StintTests {
+    @Test func stintInitialization() {
+        let stint = Stint()
+
+        #expect(stint.endDate == nil)
+        #expect(stint.position == nil)
+        #expect(stint.player == nil)
+        #expect(stint.game == nil)
+    }
+
+    @Test func stintWithPlayerAndGame() {
+        let player = Player(name: "Alex")
+        let game = Game()
+        let stint = Stint(position: "Midfielder", player: player, game: game)
+
+        #expect(stint.position == "Midfielder")
+        #expect(stint.player === player)
+        #expect(stint.game === game)
+    }
+}

--- a/SubTimerTests/TeamTests.swift
+++ b/SubTimerTests/TeamTests.swift
@@ -1,0 +1,36 @@
+//
+//  TeamTests.swift
+//  SubTimerTests
+//
+//  Created by SubTimer on 8/6/26.
+//
+
+import Foundation
+@testable import SubTimer
+import SwiftData
+import Testing
+
+struct TeamTests {
+    @Test func teamInitialization() {
+        let team = Team(name: "Warriors", sport: "Soccer")
+
+        #expect(team.name == "Warriors")
+        #expect(team.sport == "Soccer")
+        #expect(team.preferredPlayTimeSeconds == 180)
+        #expect(team.activePlayersCount == 4)
+        #expect(team.rosterMemberships == nil)
+        #expect(team.games == nil)
+    }
+
+    @Test func teamCustomDefaults() {
+        let team = Team(
+            name: "Sharks",
+            sport: "Basketball",
+            preferredPlayTimeSeconds: 240,
+            activePlayersCount: 5
+        )
+
+        #expect(team.preferredPlayTimeSeconds == 240)
+        #expect(team.activePlayersCount == 5)
+    }
+}

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -2,7 +2,7 @@
 
 The persisted model is mid-transition between two shapes:
 
-- **In use:** `Player`, `Session`, `OrderManager`, `AppConfiguration` — back
+- **In use:** `Player`, `Session`, `OrderManager`, `AppConfiguration` — backing
   all current app behavior. Of these, `Player` continues to exist once the
   transition is complete; `Session`, `OrderManager`, and `AppConfiguration`
   are expected to be superseded by the dormant types below.

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -1,0 +1,72 @@
+# Data model
+
+The persisted model is mid-transition between two shapes:
+
+- **In use:** `Player`, `Session`, `OrderManager`, `AppConfiguration` — back
+  all current app behavior. Of these, `Player` continues to exist once the
+  transition is complete; `Session`, `OrderManager`, and `AppConfiguration`
+  are expected to be superseded by the dormant types below.
+- **Present but dormant:** `Team`, `RosterMembership`, `Game`, `Stint` —
+  declared in the schema; no app code reads or writes them yet.
+
+```mermaid
+classDiagram
+    class Player {
+        <<in use>>
+    }
+    class Session {
+        <<in use>>
+    }
+    class OrderManager {
+        <<in use>>
+    }
+    class AppConfiguration {
+        <<in use>>
+    }
+
+    class Team {
+        <<dormant>>
+        +String name
+        +String sport
+        +Int preferredPlayTimeSeconds
+        +Int activePlayersCount
+    }
+    class RosterMembership {
+        <<dormant>>
+        +String? position
+    }
+    class Game {
+        <<dormant>>
+        +Date startDate
+        +Date? endDate
+        +Int substitutionCount
+        +Int preferredPlayTimeSeconds
+        +Int activePlayersCount
+        +UUID[] activeOrder
+        +UUID[] benchOrder
+        +UUID[] temporarilyOut
+    }
+    class Stint {
+        <<dormant>>
+        +Date startDate
+        +Date? endDate
+        +String? position
+    }
+
+    Team "1" o-- "0..*" RosterMembership : optional relationship
+    Player "1" o-- "0..*" RosterMembership : optional relationship
+    Team "1" o-- "0..*" Game : optional relationship
+    Game "1" o-- "0..*" Stint : optional relationship
+    Player "1" o-- "0..*" Stint : optional relationship
+```
+
+## Notes
+
+- Every relationship is optional, no type uses `@Attribute(.unique)`, and
+  ordered/unordered ID collections (`activeOrder`, `benchOrder`,
+  `temporarilyOut`) are plain value attributes rather than `@Relationship`
+  arrays. These are CloudKit sync constraints, not stylistic choices — see
+  [ADR-0001](../adr/0001-local-only-persistence-no-cloudkit.md).
+- The app's shipped `ModelConfiguration` remains local-only
+  (`cloudKitDatabase: .none`) per ADR-0001, even though the schema above is
+  already shaped to be CloudKit-compatible.


### PR DESCRIPTION
## Summary

Adds `Team`, `RosterMembership`, `Game`, and `Stint` as new SwiftData `@Model` types, alongside the existing `Player`, `Session`, `OrderManager`, `AppConfiguration`. Dormant and additive — nothing in the app reads or writes them yet, and behavior is unchanged.

This is the "expand" step of an expand-contract migration (parent: #55).

## What changed

- **New types** (`SubTimer/Models/{Team,RosterMembership,Game,Stint}.swift`) match the field shapes and relationship cardinality from the ticket exactly: no `@Attribute(.unique)`, every relationship optional, `activeOrder`/`benchOrder`/`temporarilyOut` kept as plain `[UUID]`/`Set<UUID>` value attributes rather than `@Relationship` arrays.
- **`SubTimerTests/CloudKitSchemaTests.swift`** builds the full schema (new + existing types) and initializes a real `ModelContainer` under a CloudKit-configured, dev/debug-only `ModelConfiguration` — proving CloudKit-compatibility for real, not just by inspection. The app's shipped configuration remains local-only (`cloudKitDatabase: .none`, per ADR-0001) — this test doesn't turn on sync.
- **Mechanical fixes to the 4 pre-existing models** (`Player`, `Session`, `OrderManager`, `AppConfiguration`), required to make the CloudKit test pass for the *whole* schema, not just the new types:
  - Default values moved from `init` parameter defaults onto the stored properties themselves — CloudKit only recognizes a default when it's declared inline on the property. Same values throughout, zero behavior change.
  - `Player` gained two new, currently-unused relationship arrays (`rosterMemberships`, `stints`) — CloudKit requires every relationship to have a declared inverse, and these are the inverse side of `RosterMembership.player`/`Stint.player`.
  - Every duplicated literal default is now a single `static let` per type, referenced by both the property and the `init` parameter, so the two can't drift independently.
- **`docs/architecture/data-model.md`** — new doc describing the current model as in-use vs. dormant/transitional, plus the CloudKit constraints driving the shape.

## Acceptance criteria (from #57)

- [x] `Team`, `RosterMembership`, `Game`, `Stint` exist as `@Model` types matching the field shapes
- [x] No `@Attribute(.unique)` on any new type
- [x] Every relationship on the new types is optional
- [x] `activeOrder`/`benchOrder` are plain `[UUID]`, not `@Relationship`
- [x] A CloudKit-configured `ModelConfiguration` (dev/debug only) initializes against the full schema without error
- [x] Existing app behavior and test suite are unaffected
- [x] `docs/architecture/data-model.md` created with the ticket's UML diagram

## Testing

- `swiftlint lint --strict` clean across the whole repo
- Full suite passing: 68 unit tests (`SubTimerTests`, including the new `CloudKitSchemaTests`, `TeamTests`, `RosterMembershipTests`, `GameTests`, `StintTests`) + 25 UI tests (`SubTimerUITests`)

Closes #57