### PR TITLE
feat: migrate legacy Player/Session/AppConfiguration data to Team/RosterMembership/Game

### DIFF
--- a/SubTimer.xcodeproj/project.pbxproj
+++ b/SubTimer.xcodeproj/project.pbxproj
@@ -57,6 +57,22 @@
 		4D4D7A5A2F54A87600499044 /* ActiveBenchExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ActiveBenchExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		4D4D7A5C2F54A87600499044 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		4D4D7A5E2F54A87600499044 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		4DA5CA153034759D0093BCBE /* AGENTS.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = AGENTS.md; sourceTree = "<group>"; };
+		4DA5CA163034759D0093BCBE /* CONTEXT.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTEXT.md; sourceTree = "<group>"; };
+		4DA5CA173034759D0093BCBE /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		4DA5CA18303475AD0093BCBE /* 0001-local-only-persistence-no-cloudkit.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "0001-local-only-persistence-no-cloudkit.md"; sourceTree = "<group>"; };
+		4DA5CA19303475AD0093BCBE /* 0002-swipe-actions-for-player-row-actions.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "0002-swipe-actions-for-player-row-actions.md"; sourceTree = "<group>"; };
+		4DA5CA1A303475AD0093BCBE /* 0003-explicit-test-plan-not-autocreated.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "0003-explicit-test-plan-not-autocreated.md"; sourceTree = "<group>"; };
+		4DA5CA1B303475AD0093BCBE /* 0004-bench-active-order-as-dedicated-records.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "0004-bench-active-order-as-dedicated-records.md"; sourceTree = "<group>"; };
+		4DA5CA1C303475AD0093BCBE /* 0005-pinned-ci-runner-and-xcode-versions.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "0005-pinned-ci-runner-and-xcode-versions.md"; sourceTree = "<group>"; };
+		4DA5CA1D303475AD0093BCBE /* 0006-ci-only-test-plan-for-flaky-skips.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "0006-ci-only-test-plan-for-flaky-skips.md"; sourceTree = "<group>"; };
+		4DA5CA1E303475AD0093BCBE /* 0007-plain-script-pre-commit-hook.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "0007-plain-script-pre-commit-hook.md"; sourceTree = "<group>"; };
+		4DA5CA1F303475AD0093BCBE /* 0008-defer-clone-based-parallel-testing.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "0008-defer-clone-based-parallel-testing.md"; sourceTree = "<group>"; };
+		4DA5CA20303475AD0093BCBE /* 0009-no-deriveddata-cache-in-ci.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "0009-no-deriveddata-cache-in-ci.md"; sourceTree = "<group>"; };
+		4DA5CA22303475AD0093BCBE /* domain.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = domain.md; sourceTree = "<group>"; };
+		4DA5CA23303475AD0093BCBE /* issue-tracker.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "issue-tracker.md"; sourceTree = "<group>"; };
+		4DA5CA24303475AD0093BCBE /* triage-labels.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "triage-labels.md"; sourceTree = "<group>"; };
+		4DA5CA26303475AD0093BCBE /* data-model.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "data-model.md"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -173,10 +189,58 @@
 		4D4D7A5B2F54A87600499044 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				4DA5CA153034759D0093BCBE /* AGENTS.md */,
+				4DA5CA163034759D0093BCBE /* CONTEXT.md */,
+				4DA5CA173034759D0093BCBE /* README.md */,
 				4D4D7A5C2F54A87600499044 /* WidgetKit.framework */,
 				4D4D7A5E2F54A87600499044 /* SwiftUI.framework */,
+				4DA5CA28303475AD0093BCBE /* docs */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		4DA5CA21303475AD0093BCBE /* adr */ = {
+			isa = PBXGroup;
+			children = (
+				4DA5CA18303475AD0093BCBE /* 0001-local-only-persistence-no-cloudkit.md */,
+				4DA5CA19303475AD0093BCBE /* 0002-swipe-actions-for-player-row-actions.md */,
+				4DA5CA1A303475AD0093BCBE /* 0003-explicit-test-plan-not-autocreated.md */,
+				4DA5CA1B303475AD0093BCBE /* 0004-bench-active-order-as-dedicated-records.md */,
+				4DA5CA1C303475AD0093BCBE /* 0005-pinned-ci-runner-and-xcode-versions.md */,
+				4DA5CA1D303475AD0093BCBE /* 0006-ci-only-test-plan-for-flaky-skips.md */,
+				4DA5CA1E303475AD0093BCBE /* 0007-plain-script-pre-commit-hook.md */,
+				4DA5CA1F303475AD0093BCBE /* 0008-defer-clone-based-parallel-testing.md */,
+				4DA5CA20303475AD0093BCBE /* 0009-no-deriveddata-cache-in-ci.md */,
+			);
+			path = adr;
+			sourceTree = "<group>";
+		};
+		4DA5CA25303475AD0093BCBE /* agents */ = {
+			isa = PBXGroup;
+			children = (
+				4DA5CA22303475AD0093BCBE /* domain.md */,
+				4DA5CA23303475AD0093BCBE /* issue-tracker.md */,
+				4DA5CA24303475AD0093BCBE /* triage-labels.md */,
+			);
+			path = agents;
+			sourceTree = "<group>";
+		};
+		4DA5CA27303475AD0093BCBE /* architecture */ = {
+			isa = PBXGroup;
+			children = (
+				4DA5CA26303475AD0093BCBE /* data-model.md */,
+			);
+			path = architecture;
+			sourceTree = "<group>";
+		};
+		4DA5CA28303475AD0093BCBE /* docs */ = {
+			isa = PBXGroup;
+			children = (
+				4DA5CA21303475AD0093BCBE /* adr */,
+				4DA5CA25303475AD0093BCBE /* agents */,
+				4DA5CA27303475AD0093BCBE /* architecture */,
+			);
+			path = docs;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/SubTimer/Models/Game.swift
+++ b/SubTimer/Models/Game.swift
@@ -10,6 +10,7 @@ import SwiftData
 
 @Model
 final class Game {
+    static let defaultDuration: TimeInterval = 0
     static let defaultSubstitutionCount = 0
     static let defaultPreferredPlayTimeSeconds = 180
     static let defaultActivePlayersCount = 4
@@ -20,6 +21,7 @@ final class Game {
     var id = UUID()
     var startDate = Date()
     var endDate: Date?
+    var duration = Game.defaultDuration
     var substitutionCount = Game.defaultSubstitutionCount
     var preferredPlayTimeSeconds = Game.defaultPreferredPlayTimeSeconds
     var activePlayersCount = Game.defaultActivePlayersCount
@@ -37,6 +39,7 @@ final class Game {
         id: UUID = UUID(),
         startDate: Date = Date(),
         endDate: Date? = nil,
+        duration: TimeInterval = Game.defaultDuration,
         substitutionCount: Int = Game.defaultSubstitutionCount,
         preferredPlayTimeSeconds: Int = Game.defaultPreferredPlayTimeSeconds,
         activePlayersCount: Int = Game.defaultActivePlayersCount,
@@ -48,6 +51,7 @@ final class Game {
         self.id = id
         self.startDate = startDate
         self.endDate = endDate
+        self.duration = duration
         self.substitutionCount = substitutionCount
         self.preferredPlayTimeSeconds = preferredPlayTimeSeconds
         self.activePlayersCount = activePlayersCount

--- a/SubTimer/Models/SchemaMigrationPlan.swift
+++ b/SubTimer/Models/SchemaMigrationPlan.swift
@@ -1,0 +1,138 @@
+//
+//  SchemaMigrationPlan.swift
+//  SubTimer
+//
+//  Created by SubTimer on 8/17/26.
+//
+
+import Foundation
+import SwiftData
+
+/// The schema shape prior to #57: `Player`, `AppConfiguration`, `Session`, and
+/// `OrderManager` only.
+///
+/// `AppConfiguration`/`Session`/`OrderManager` reuse the current model classes
+/// directly, since their shapes never changed. `Player` needs its own frozen
+/// snapshot here instead: the real `Player` class already carries #57's
+/// `rosterMemberships`/`stints` relationships into `RosterMembership`/`Stint`,
+/// and reusing it as-is would pull those (and, transitively, `Team`/`Game`)
+/// into this version's compiled model too — making it indistinguishable from
+/// `SchemaV2` and crashing migration with "the current model reference and
+/// the next model reference cannot be equal".
+enum SchemaV1: VersionedSchema {
+    static var versionIdentifier = Schema.Version(1, 0, 0)
+
+    static var models: [any PersistentModel.Type] {
+        [Player.self, AppConfiguration.self, Session.self, OrderManager.self]
+    }
+
+    @Model
+    final class Player {
+        var id = UUID()
+        var name: String = ""
+        var createdDate = Date()
+        var currentPlayDuration: TimeInterval = 0
+        var totalPlayTime: TimeInterval = 0
+        var status = PlayerStatus.benched
+        var sortOrder = 0
+        var activatedAtDate = Date()
+
+        init(name: String) {
+            self.name = name
+        }
+    }
+}
+
+/// The schema shape from #57 onward: everything in `SchemaV1` plus the
+/// dormant `Team`, `RosterMembership`, `Game`, and `Stint` models.
+enum SchemaV2: VersionedSchema {
+    static var versionIdentifier = Schema.Version(2, 0, 0)
+
+    static var models: [any PersistentModel.Type] {
+        [
+            Player.self,
+            AppConfiguration.self,
+            Session.self,
+            OrderManager.self,
+            Team.self,
+            RosterMembership.self,
+            Game.self,
+            Stint.self
+        ]
+    }
+}
+
+/// Drives the one-time transform of legacy `Player`/`Session`/`AppConfiguration`
+/// rows into the `Team`/`RosterMembership`/`Game` shape added by #57, on
+/// `ModelContainer` open. See docs/architecture/data-model.md for the full
+/// sequence diagram.
+///
+/// This purely produces correct rows for later tickets to wire up — no
+/// `GameManager`/`TeamManager` involvement, no UI, no behavior change.
+enum SubTimerMigrationPlan: SchemaMigrationPlan {
+    static var schemas: [any VersionedSchema.Type] {
+        [SchemaV1.self, SchemaV2.self]
+    }
+
+    static var stages: [MigrationStage] {
+        [migrateV1toV2]
+    }
+
+    static let migrateV1toV2 = MigrationStage.custom(
+        fromVersion: SchemaV1.self,
+        toVersion: SchemaV2.self,
+        willMigrate: nil,
+        didMigrate: { context in
+            try migrateLegacyDataToTeamModel(in: context)
+        }
+    )
+}
+
+/// Auto-creates exactly one `Team` — seeded from the existing `AppConfiguration`
+/// singleton, falling back to its static defaults when none exists — a
+/// `RosterMembership` (no position) for every existing `Player` into that
+/// `Team`, and a `Game` for every existing `Session`, carrying over
+/// `startDate`/`endDate`/`duration`/`substitutionCount`/`preferredPlayTimeSeconds`/
+/// `activePlayersCount`.
+///
+/// Guarded by "does any `Team` already exist" *before* creating any row, so
+/// running this twice (e.g. app relaunch after a partial/completed migration)
+/// never creates a second `Team` or duplicate `RosterMembership`/`Game` rows.
+func migrateLegacyDataToTeamModel(in context: ModelContext) throws {
+    guard try context.fetch(FetchDescriptor<Team>()).isEmpty else {
+        return
+    }
+
+    let configuration = try context.fetch(FetchDescriptor<AppConfiguration>()).first
+    let team = Team(
+        name: "",
+        sport: "",
+        preferredPlayTimeSeconds: configuration?.preferredPlayTimeSeconds
+            ?? AppConfiguration.defaultPreferredPlayTimeSeconds,
+        activePlayersCount: configuration?.activePlayersCount
+            ?? AppConfiguration.defaultActivePlayersCount
+    )
+    context.insert(team)
+
+    let players = try context.fetch(FetchDescriptor<Player>())
+    for player in players {
+        context.insert(RosterMembership(player: player, team: team))
+    }
+
+    let sessions = try context.fetch(FetchDescriptor<Session>())
+    for session in sessions {
+        context.insert(
+            Game(
+                startDate: session.startDate,
+                endDate: session.endDate,
+                duration: session.duration,
+                substitutionCount: session.substitutionCount,
+                preferredPlayTimeSeconds: session.preferredPlayTimeSeconds,
+                activePlayersCount: session.activePlayersCount,
+                team: team
+            )
+        )
+    }
+
+    try context.save()
+}

--- a/SubTimer/Models/SchemaMigrationPlan.swift
+++ b/SubTimer/Models/SchemaMigrationPlan.swift
@@ -98,8 +98,8 @@ enum SubTimerMigrationPlan: SchemaMigrationPlan {
 /// Guarded by "does any `Team` already exist" *before* creating any row, so
 /// running this twice (e.g. app relaunch after a partial/completed migration)
 /// never creates a second `Team` or duplicate `RosterMembership`/`Game` rows.
-func migrateLegacyDataToTeamModel(in context: ModelContext) throws {
-    guard try context.fetch(FetchDescriptor<Team>()).isEmpty else {
+private func migrateLegacyDataToTeamModel(in context: ModelContext) throws {
+    guard try context.fetchCount(FetchDescriptor<Team>()) == 0 else {
         return
     }
 

--- a/SubTimer/SubTimerApp.swift
+++ b/SubTimer/SubTimerApp.swift
@@ -22,16 +22,7 @@ struct SubTimerApp: App {
     // MARK: - Model Container Setup
 
     private static func makeModelContainer() -> ModelContainer {
-        let schema = Schema([
-            Player.self,
-            AppConfiguration.self,
-            Session.self,
-            OrderManager.self,
-            Team.self,
-            RosterMembership.self,
-            Game.self,
-            Stint.self
-        ])
+        let schema = Schema(versionedSchema: SchemaV2.self)
 
         // Use in-memory storage for UI testing
         let isUITesting = CommandLine.arguments.contains("--uitesting")
@@ -42,7 +33,11 @@ struct SubTimerApp: App {
         )
 
         do {
-            let container = try ModelContainer(for: schema, configurations: [modelConfiguration])
+            let container = try ModelContainer(
+                for: schema,
+                migrationPlan: SubTimerMigrationPlan.self,
+                configurations: [modelConfiguration]
+            )
 
             // Add test data when in UI testing mode
             if isUITesting {
@@ -81,7 +76,11 @@ struct SubTimerApp: App {
         )
 
         do {
-            let container = try ModelContainer(for: schema, configurations: [modelConfiguration])
+            let container = try ModelContainer(
+                for: schema,
+                migrationPlan: SubTimerMigrationPlan.self,
+                configurations: [modelConfiguration]
+            )
             if isUITesting {
                 setupTestData(in: container)
             }

--- a/SubTimerTests/DataMigrationTests.swift
+++ b/SubTimerTests/DataMigrationTests.swift
@@ -1,0 +1,127 @@
+//
+//  DataMigrationTests.swift
+//  SubTimerTests
+//
+//  Created by SubTimer on 8/17/26.
+//
+
+import Foundation
+@testable import SubTimer
+import SwiftData
+import Testing
+
+/// Exercises `SubTimerMigrationPlan` end-to-end: a fixture pre-#57 store is
+/// seeded under `SchemaV1` alone (no migration plan involved yet, matching
+/// what a real pre-#57 install would have on disk), then reopened through the
+/// full plan the way `SubTimerApp` does on every launch.
+struct DataMigrationTests {
+    private func makeStoreURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("DataMigrationTests-\(UUID().uuidString)")
+            .appendingPathExtension("sqlite")
+    }
+
+    private func removeStore(at url: URL) {
+        try? FileManager.default.removeItem(at: url)
+        try? FileManager.default.removeItem(
+            at: url.deletingPathExtension().appendingPathExtension("sqlite-shm")
+        )
+        try? FileManager.default.removeItem(
+            at: url.deletingPathExtension().appendingPathExtension("sqlite-wal")
+        )
+    }
+
+    private func seedLegacyStore(at url: URL) throws {
+        let schema = Schema(versionedSchema: SchemaV1.self)
+        let configuration = ModelConfiguration(schema: schema, url: url, cloudKitDatabase: .none)
+        let container = try ModelContainer(for: schema, configurations: [configuration])
+        let context = ModelContext(container)
+
+        // Explicitly SchemaV1.Player, not the real (post-#57) `Player`: an
+        // unqualified `Player(...)` here would resolve to the top-level class,
+        // which carries relationships this schema's compiled model doesn't
+        // declare — defeating the point of seeding a genuine pre-#57 store.
+        context.insert(SchemaV1.Player(name: "Alice"))
+        context.insert(SchemaV1.Player(name: "Bob"))
+        context.insert(AppConfiguration(preferredPlayTimeSeconds: 240, activePlayersCount: 6))
+        context.insert(Session(
+            startDate: Date(timeIntervalSince1970: 1_000),
+            endDate: Date(timeIntervalSince1970: 1_900),
+            duration: 900,
+            substitutionCount: 3,
+            preferredPlayTimeSeconds: 240,
+            activePlayersCount: 6
+        ))
+
+        try context.save()
+    }
+
+    private func openMigratedStore(at url: URL) throws -> ModelContainer {
+        let schema = Schema(versionedSchema: SchemaV2.self)
+        let configuration = ModelConfiguration(schema: schema, url: url, cloudKitDatabase: .none)
+        return try ModelContainer(
+            for: schema,
+            migrationPlan: SubTimerMigrationPlan.self,
+            configurations: [configuration]
+        )
+    }
+
+    @Test func migratesLegacyPlayersSessionsAndConfigurationIntoNewModel() throws {
+        let url = makeStoreURL()
+        defer { removeStore(at: url) }
+        try seedLegacyStore(at: url)
+
+        let container = try openMigratedStore(at: url)
+        let context = ModelContext(container)
+
+        let teams = try context.fetch(FetchDescriptor<Team>())
+        #expect(teams.count == 1)
+        let team = try #require(teams.first)
+        #expect(team.preferredPlayTimeSeconds == 240)
+        #expect(team.activePlayersCount == 6)
+
+        let memberships = try context.fetch(FetchDescriptor<RosterMembership>())
+        #expect(memberships.count == 2)
+        #expect(memberships.allSatisfy { $0.team?.id == team.id })
+        #expect(memberships.allSatisfy { $0.position == nil })
+        #expect(Set(memberships.compactMap { $0.player?.name }) == ["Alice", "Bob"])
+
+        let games = try context.fetch(FetchDescriptor<Game>())
+        #expect(games.count == 1)
+        let game = try #require(games.first)
+        #expect(game.team?.id == team.id)
+        #expect(game.startDate == Date(timeIntervalSince1970: 1_000))
+        #expect(game.endDate == Date(timeIntervalSince1970: 1_900))
+        #expect(game.duration == 900)
+        #expect(game.substitutionCount == 3)
+    }
+
+    @Test func reopeningMigratedStoreDoesNotDuplicateRows() throws {
+        let url = makeStoreURL()
+        defer { removeStore(at: url) }
+        try seedLegacyStore(at: url)
+
+        _ = try openMigratedStore(at: url)
+        let context = ModelContext(try openMigratedStore(at: url))
+
+        #expect(try context.fetch(FetchDescriptor<Team>()).count == 1)
+        #expect(try context.fetch(FetchDescriptor<RosterMembership>()).count == 2)
+        #expect(try context.fetch(FetchDescriptor<Game>()).count == 1)
+    }
+
+    @Test func seedsTeamDefaultsWhenNoAppConfigurationExists() throws {
+        let url = makeStoreURL()
+        defer { removeStore(at: url) }
+
+        let schema = Schema(versionedSchema: SchemaV1.self)
+        let configuration = ModelConfiguration(schema: schema, url: url, cloudKitDatabase: .none)
+        let legacyContainer = try ModelContainer(for: schema, configurations: [configuration])
+        try ModelContext(legacyContainer).save()
+
+        let context = ModelContext(try openMigratedStore(at: url))
+        let team = try #require(try context.fetch(FetchDescriptor<Team>()).first)
+
+        #expect(team.preferredPlayTimeSeconds == AppConfiguration.defaultPreferredPlayTimeSeconds)
+        #expect(team.activePlayersCount == AppConfiguration.defaultActivePlayersCount)
+    }
+}

--- a/SubTimerTests/GameTests.swift
+++ b/SubTimerTests/GameTests.swift
@@ -15,6 +15,7 @@ struct GameTests {
         let game = Game()
 
         #expect(game.endDate == nil)
+        #expect(game.duration == 0)
         #expect(game.substitutionCount == 0)
         #expect(game.preferredPlayTimeSeconds == 180)
         #expect(game.activePlayersCount == 4)
@@ -41,5 +42,11 @@ struct GameTests {
         let game = Game(team: team)
 
         #expect(game.team === team)
+    }
+
+    @Test func gameDurationIsSettableViaInit() {
+        let game = Game(duration: 942)
+
+        #expect(game.duration == 942)
     }
 }

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -39,6 +39,7 @@ classDiagram
         <<dormant>>
         +Date startDate
         +Date? endDate
+        +TimeInterval duration
         +Int substitutionCount
         +Int preferredPlayTimeSeconds
         +Int activePlayersCount
@@ -136,4 +137,47 @@ sequenceDiagram
     GameManager->>Game: append playerId to activeOrder
     GameManager->>Stint: open new Stint(player, game, startDate: now)
     GameManager-->>Caller: bucket membership + Stint updated atomically, in one call
+```
+
+## Legacy data migration (#59)
+
+A one-time, idempotent transform, driven by `SubTimerMigrationPlan`
+(`SchemaV1` → `SchemaV2`) on `ModelContainer` open, that populates the
+dormant `Team`/`RosterMembership`/`Game` rows from the in-use
+`Player`/`Session`/`AppConfiguration` data. No `GameManager`/`TeamManager`
+involvement — this only produces correct rows for later tickets to wire up.
+
+`SchemaV1` gives `Player` its own frozen, relationship-free snapshot rather
+than reusing the real `Player` class: the real class already carries #57's
+`rosterMemberships`/`stints` relationships, and reusing it as-is would pull
+`RosterMembership`/`Stint`/`Team` into `SchemaV1`'s compiled model too,
+making it indistinguishable from `SchemaV2`. `AppConfiguration`/`Session`/
+`OrderManager` have no such relationships, so `SchemaV2` reuses them —
+and the real `Player`/`Team`/`RosterMembership`/`Game`/`Stint` — directly.
+
+`Game` gained a `duration: TimeInterval` field as part of this ticket: it
+has no other way to preserve an in-progress `Session`'s elapsed time (`Session.endDate`
+is `nil` while active, so `duration` can't be re-derived from
+`startDate`/`endDate` alone), mirroring `Session`'s own two-field shape.
+
+```mermaid
+sequenceDiagram
+    participant App as App launch
+    participant Plan as SchemaMigrationPlan
+    participant Legacy as V1 store (Player, Session, AppConfiguration)
+    participant New as V2 store (Team, RosterMembership, Game)
+
+    App->>Plan: open ModelContainer
+    Plan->>New: check for existing migrated Team
+    alt already migrated
+        Plan-->>App: no-op, reuse existing Team/RosterMembership/Game rows
+    else not yet migrated
+        Plan->>Legacy: read AppConfiguration singleton
+        Plan->>New: create Team (preferredPlayTimeSeconds/activePlayersCount seeded from AppConfiguration)
+        Plan->>Legacy: read every Player
+        Plan->>New: create one RosterMembership(player, team) per Player, position = nil
+        Plan->>Legacy: read every Session
+        Plan->>New: create one Game(team) per Session, copying startDate/endDate/duration/substitutionCount
+        Plan-->>App: migration complete
+    end
 ```


### PR DESCRIPTION
Retrofits `VersionedSchema` (`SchemaV1`/`SchemaV2`) and a `SchemaMigrationPlan` onto `SubTimerApp`'s `ModelContainer`, driving a one-time, idempotent transform on container open: auto-creates exactly one `Team` (seeded from the existing `AppConfiguration` singleton, falling back to its static defaults), a `RosterMembership` per `Player`, and a `Game` per `Session`, carrying over `startDate`/`endDate`/`duration`/`substitutionCount`/`preferredPlayTimeSeconds`/`activePlayersCount`. Guarded by "does any Team already exist" before any row is created, so relaunch after a partial/completed migration never duplicates rows.

Adds `Game.duration` (mirroring `Session`'s own two-field shape) since an in-progress `Session`'s elapsed time can't always be re-derived from `startDate`/`endDate` alone. `SchemaV1` gets its own frozen, relationship-free `Player` snapshot rather than reusing the real class, which already carries #57's dormant relationships into `RosterMembership`/`Stint` and would otherwise make `SchemaV1`'s compiled model indistinguishable from `SchemaV2`.

Closes #59.