### PR TITLE
Rewire TimerView activate/bench/temporarily-out actions onto GameManager

### DIFF
--- a/SubTimer/Models/GameManager.swift
+++ b/SubTimer/Models/GameManager.swift
@@ -36,6 +36,17 @@ struct Substitution: Equatable {
     let incomingPlayerId: UUID
 }
 
+/// The old `Player.status`/`OrderManager`-driven rotation state, captured as
+/// input to `GameManager.seedFromLegacyStatus`. These five values only ever
+/// travel together, for that one purpose — see issue #60.
+struct LegacyRotationSnapshot {
+    let activePlayers: [Player]
+    let benchedPlayers: [Player]
+    let temporarilyOutPlayers: [Player]
+    let existingActiveOrder: [UUID]
+    let existingBenchOrder: [UUID]
+}
+
 /// Sole mutator of `Game.activeOrder`/`benchOrder`/`temporarilyOut` and sole
 /// opener/closer of `Stint`s. Plain (non-`@Model`) class — see #58: nothing in the
 /// app calls this yet, it operates purely on the dormant schema from #57 via an
@@ -180,5 +191,96 @@ final class GameManager {
             .reduce(0) { total, stint in
                 total + (stint.endDate ?? now).timeIntervalSince(stint.startDate)
             }
+    }
+
+    /// Resolves which `RotationBucket` `playerId` currently occupies in `game`.
+    /// Defaults to `.benched` when the player is in none of the three buckets
+    /// (e.g. a roster player never yet transitioned into this `Game`'s
+    /// rotation) — matching `Player.defaultStatus`'s old-model default, so a
+    /// player's very first appearance renders the same way under both models.
+    func status(playerId: UUID, in game: Game) -> RotationBucket {
+        if game.activeOrder.contains(playerId) {
+            return .active
+        }
+        if game.temporarilyOut.contains(playerId) {
+            return .temporarilyOut
+        }
+        return .benched
+    }
+
+    /// Replaces `bucket`'s order in `game` with `playerIds`, without changing
+    /// bucket membership — the caller is responsible for passing the same
+    /// membership, just reordered (e.g. drag-to-reorder). A `.temporarilyOut`
+    /// bucket is a no-op, since `Game.temporarilyOut` is an unordered `Set`.
+    /// Kept alongside `transition` so `Game.activeOrder`/`benchOrder` still
+    /// only ever change through `GameManager`.
+    func setOrder(_ playerIds: [UUID], for bucket: RotationBucket, in game: Game) {
+        switch bucket {
+        case .active:
+            game.activeOrder = playerIds
+        case .benched:
+            game.benchOrder = playerIds
+        case .temporarilyOut:
+            break
+        }
+    }
+
+    /// One-time migration bridge (see issue #60): seeds a freshly-created,
+    /// history-less `game`'s bucket membership and `Stint`s from the old
+    /// `Player.status`-driven model, so an in-progress rotation (or a
+    /// `--uitesting` fixture launch) carries over exactly instead of
+    /// resetting the first time `TimerView` starts operating on `Game`. Not
+    /// part of the ordinary `transition`/substitution API — only ever
+    /// called once, immediately after `game` is created.
+    ///
+    /// `snapshot.existingActiveOrder`/`existingBenchOrder` (typically the
+    /// legacy `OrderManager.playerOrder`) are preserved for players present
+    /// in each, so a coach's existing custom order survives. Each player's
+    /// prior `totalPlayTime` becomes a closed, synthetic `Stint` (only its
+    /// duration matters — `totalPlayTime`/`currentPlayDuration` are always
+    /// derived by summing `Stint`s, never by a `Stint`'s actual dates); an
+    /// `.active` player additionally gets a second, open `Stint` starting
+    /// at their existing `activatedAtDate`, so their current segment's
+    /// elapsed time carries over too.
+    func seedFromLegacyStatus(_ snapshot: LegacyRotationSnapshot, in game: Game) {
+        game.activeOrder = preservingOrder(of: snapshot.activePlayers, matching: snapshot.existingActiveOrder)
+        game.benchOrder = preservingOrder(of: snapshot.benchedPlayers, matching: snapshot.existingBenchOrder)
+        game.temporarilyOut = Set(snapshot.temporarilyOutPlayers.map { $0.id })
+
+        var stints: [Stint] = []
+        for player in snapshot.benchedPlayers + snapshot.temporarilyOutPlayers {
+            if let historicalStint = historicalStint(for: player, in: game) {
+                stints.append(historicalStint)
+            }
+        }
+        for player in snapshot.activePlayers {
+            if let historicalStint = historicalStint(for: player, in: game) {
+                stints.append(historicalStint)
+            }
+            stints.append(Stint(startDate: player.activatedAtDate, player: player, game: game))
+        }
+
+        for stint in stints {
+            context.insert(stint)
+        }
+        game.stints = stints
+    }
+
+    /// A closed `Stint` whose duration equals `player.totalPlayTime`, or
+    /// `nil` when there's nothing to carry over. Start/end dates are
+    /// otherwise arbitrary, ending at `Date()` so it never reads as
+    /// still-open.
+    private func historicalStint(for player: Player, in game: Game) -> Stint? {
+        guard player.totalPlayTime > 0 else { return nil }
+        let end = Date()
+        return Stint(startDate: end.addingTimeInterval(-player.totalPlayTime), endDate: end, player: player, game: game)
+    }
+
+    private func preservingOrder(of matchingPlayers: [Player], matching existingOrder: [UUID]) -> [UUID] {
+        let matchedIds = Set(matchingPlayers.map { $0.id })
+        let ordered = existingOrder.filter { matchedIds.contains($0) }
+        let orderedSet = Set(ordered)
+        let remaining = matchingPlayers.filter { !orderedSet.contains($0.id) }.map { $0.id }
+        return ordered + remaining
     }
 }

--- a/SubTimer/SubTimerApp.swift
+++ b/SubTimer/SubTimerApp.swift
@@ -100,11 +100,16 @@ struct SubTimerApp: App {
         player1.status = .active
         player1.currentPlayDuration = 120
         player1.totalPlayTime = 300
+        // TimerView bootstraps its first Game's Stints from activatedAtDate
+        // (see TimerView.seedGameFromLegacyStatus) - backdating this keeps
+        // GameManager.currentPlayDuration in sync with currentPlayDuration above.
+        player1.activatedAtDate = Date().addingTimeInterval(-120)
 
         let player2 = Player(name: "Bob Smith")
         player2.status = .active
         player2.currentPlayDuration = 90
         player2.totalPlayTime = 250
+        player2.activatedAtDate = Date().addingTimeInterval(-90)
 
         let player3 = Player(name: "Charlie Brown")
         player3.status = .benched

--- a/SubTimer/SubTimerApp.swift
+++ b/SubTimer/SubTimerApp.swift
@@ -101,7 +101,8 @@ struct SubTimerApp: App {
         player1.currentPlayDuration = 120
         player1.totalPlayTime = 300
         // TimerView bootstraps its first Game's Stints from activatedAtDate
-        // (see TimerView.seedGameFromLegacyStatus) - backdating this keeps
+        // (see GameManager.seedFromLegacyStatus, called from
+        // TimerView.resolveOrCreateGame) - backdating this keeps
         // GameManager.currentPlayDuration in sync with currentPlayDuration above.
         player1.activatedAtDate = Date().addingTimeInterval(-120)
 

--- a/SubTimer/Views/Components/Players/ActivePlayerRowView.swift
+++ b/SubTimer/Views/Components/Players/ActivePlayerRowView.swift
@@ -12,6 +12,7 @@ struct ActivePlayerRowView: View {
     // MARK: - Properties
 
     let player: Player
+    let currentPlayDuration: TimeInterval
     let isNextToSubOut: Bool
     let onTap: () -> Void
 
@@ -30,7 +31,7 @@ struct ActivePlayerRowView: View {
                             .accessibilityLabel("Next to Sub Out")
                     }
                 }
-                Text(TimeFormatter.format(player.currentPlayDuration))
+                Text(TimeFormatter.format(currentPlayDuration))
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .monospacedDigit()
@@ -55,7 +56,8 @@ struct ActivePlayerRowView: View {
 
 #Preview("Normal Active Player") {
     ActivePlayerRowView(
-        player: Player(name: "John Doe", currentPlayDuration: 120),
+        player: Player(name: "John Doe"),
+        currentPlayDuration: 120,
         isNextToSubOut: false,
         onTap: { print("Player tapped") }
     )
@@ -64,7 +66,8 @@ struct ActivePlayerRowView: View {
 
 #Preview("Next to Sub Out") {
     ActivePlayerRowView(
-        player: Player(name: "Jane Smith", currentPlayDuration: 180),
+        player: Player(name: "Jane Smith"),
+        currentPlayDuration: 180,
         isNextToSubOut: true,
         onTap: { print("Player tapped") }
     )
@@ -73,7 +76,8 @@ struct ActivePlayerRowView: View {
 
 #Preview("Long Play Time") {
     ActivePlayerRowView(
-        player: Player(name: "Mike Johnson", currentPlayDuration: 450),
+        player: Player(name: "Mike Johnson"),
+        currentPlayDuration: 450,
         isNextToSubOut: true,
         onTap: { print("Player tapped") }
     )
@@ -82,7 +86,8 @@ struct ActivePlayerRowView: View {
 
 #Preview("Zero Time") {
     ActivePlayerRowView(
-        player: Player(name: "Sarah Williams", currentPlayDuration: 0),
+        player: Player(name: "Sarah Williams"),
+        currentPlayDuration: 0,
         isNextToSubOut: false,
         onTap: { print("Player tapped") }
     )

--- a/SubTimer/Views/Components/Players/ActivePlayersSectionView.swift
+++ b/SubTimer/Views/Components/Players/ActivePlayersSectionView.swift
@@ -13,6 +13,7 @@ struct ActivePlayersSectionView: View {
 
     let players: [Player]
     let maxActiveCount: Int
+    let currentPlayDuration: (Player) -> TimeInterval
     let onPlayerTap: (Player) -> Void
     let onReorder: (([Player]) -> Void)?
 
@@ -74,6 +75,7 @@ struct ActivePlayersSectionView: View {
     private func playerRow(player: Player, index: Int) -> some View {
         ActivePlayerRowView(
             player: player,
+            currentPlayDuration: currentPlayDuration(player),
             isNextToSubOut: isNextToSubOut(index),
             onTap: { onPlayerTap(player) }
         )
@@ -111,14 +113,18 @@ struct ActivePlayersSectionView: View {
 // MARK: - Preview
 
 #Preview("With Active Players") {
+    let durations: [String: TimeInterval] = [
+        "John Doe": 120, "Jane Smith": 180, "Mike Johnson": 90, "Sarah Williams": 150
+    ]
     ActivePlayersSectionView(
         players: [
-            Player(name: "John Doe", currentPlayDuration: 120, status: .active),
-            Player(name: "Jane Smith", currentPlayDuration: 180, status: .active),
-            Player(name: "Mike Johnson", currentPlayDuration: 90, status: .active),
-            Player(name: "Sarah Williams", currentPlayDuration: 150, status: .active)
+            Player(name: "John Doe", status: .active),
+            Player(name: "Jane Smith", status: .active),
+            Player(name: "Mike Johnson", status: .active),
+            Player(name: "Sarah Williams", status: .active)
         ],
         maxActiveCount: 4,
+        currentPlayDuration: { durations[$0.name] ?? 0 },
         onPlayerTap: { player in print("Tapped: \(player.name)") },
         onReorder: { players in print("Reordered: \(players.map { $0.name })") }
     )
@@ -129,6 +135,7 @@ struct ActivePlayersSectionView: View {
     ActivePlayersSectionView(
         players: [],
         maxActiveCount: 4,
+        currentPlayDuration: { _ in 0 },
         onPlayerTap: { _ in },
         onReorder: nil
     )
@@ -138,9 +145,10 @@ struct ActivePlayersSectionView: View {
 #Preview("Single Player") {
     ActivePlayersSectionView(
         players: [
-            Player(name: "Solo Player", currentPlayDuration: 200, status: .active)
+            Player(name: "Solo Player", status: .active)
         ],
         maxActiveCount: 4,
+        currentPlayDuration: { _ in 200 },
         onPlayerTap: { _ in },
         onReorder: nil
     )
@@ -148,13 +156,15 @@ struct ActivePlayersSectionView: View {
 }
 
 #Preview("At Capacity") {
+    let durations: [String: TimeInterval] = ["Player 1": 120, "Player 2": 180, "Player 3": 90]
     ActivePlayersSectionView(
         players: [
-            Player(name: "Player 1", currentPlayDuration: 120, status: .active),
-            Player(name: "Player 2", currentPlayDuration: 180, status: .active),
-            Player(name: "Player 3", currentPlayDuration: 90, status: .active)
+            Player(name: "Player 1", status: .active),
+            Player(name: "Player 2", status: .active),
+            Player(name: "Player 3", status: .active)
         ],
         maxActiveCount: 3,
+        currentPlayDuration: { durations[$0.name] ?? 0 },
         onPlayerTap: { _ in },
         onReorder: { _ in print("Reordered") }
     )
@@ -162,12 +172,14 @@ struct ActivePlayersSectionView: View {
 }
 
 #Preview("Under Capacity") {
+    let durations: [String: TimeInterval] = ["Player 1": 120, "Player 2": 180]
     ActivePlayersSectionView(
         players: [
-            Player(name: "Player 1", currentPlayDuration: 120, status: .active),
-            Player(name: "Player 2", currentPlayDuration: 180, status: .active)
+            Player(name: "Player 1", status: .active),
+            Player(name: "Player 2", status: .active)
         ],
         maxActiveCount: 5,
+        currentPlayDuration: { durations[$0.name] ?? 0 },
         onPlayerTap: { _ in },
         onReorder: nil
     )

--- a/SubTimer/Views/Components/Players/BenchPlayerRowView.swift
+++ b/SubTimer/Views/Components/Players/BenchPlayerRowView.swift
@@ -12,6 +12,7 @@ struct BenchPlayerRowView: View {
     // MARK: - Properties
 
     let player: Player
+    let totalPlayTime: TimeInterval
     let isNextUp: Bool
     let canActivate: Bool
     let onTap: () -> Void
@@ -51,7 +52,7 @@ struct BenchPlayerRowView: View {
                         .accessibilityLabel("Next Up")
                 }
             }
-            Text("Total: \(TimeFormatter.format(player.totalPlayTime))")
+            Text("Total: \(TimeFormatter.format(totalPlayTime))")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .monospacedDigit()
@@ -83,7 +84,8 @@ struct BenchPlayerRowView: View {
 
 #Preview("Normal Bench Player") {
     BenchPlayerRowView(
-        player: Player(name: "John Doe", totalPlayTime: 180),
+        player: Player(name: "John Doe"),
+        totalPlayTime: 180,
         isNextUp: false,
         canActivate: false,
         onTap: { print("Player tapped") },
@@ -94,7 +96,8 @@ struct BenchPlayerRowView: View {
 
 #Preview("Next Up Player") {
     BenchPlayerRowView(
-        player: Player(name: "Jane Smith", totalPlayTime: 240),
+        player: Player(name: "Jane Smith"),
+        totalPlayTime: 240,
         isNextUp: true,
         canActivate: false,
         onTap: { print("Player tapped") },
@@ -105,7 +108,8 @@ struct BenchPlayerRowView: View {
 
 #Preview("Can Activate") {
     BenchPlayerRowView(
-        player: Player(name: "Mike Johnson", totalPlayTime: 120),
+        player: Player(name: "Mike Johnson"),
+        totalPlayTime: 120,
         isNextUp: false,
         canActivate: true,
         onTap: { print("Player tapped") },
@@ -116,7 +120,8 @@ struct BenchPlayerRowView: View {
 
 #Preview("Next Up & Can Activate") {
     BenchPlayerRowView(
-        player: Player(name: "Sarah Williams", totalPlayTime: 60),
+        player: Player(name: "Sarah Williams"),
+        totalPlayTime: 60,
         isNextUp: true,
         canActivate: true,
         onTap: { print("Player tapped") },
@@ -127,7 +132,8 @@ struct BenchPlayerRowView: View {
 
 #Preview("Zero Play Time") {
     BenchPlayerRowView(
-        player: Player(name: "New Player", totalPlayTime: 0),
+        player: Player(name: "New Player"),
+        totalPlayTime: 0,
         isNextUp: false,
         canActivate: true,
         onTap: { print("Player tapped") },

--- a/SubTimer/Views/Components/Players/BenchSectionView.swift
+++ b/SubTimer/Views/Components/Players/BenchSectionView.swift
@@ -14,6 +14,7 @@ struct BenchSectionView: View {
     let players: [Player]
     let activePlayersCount: Int
     let maxActiveCount: Int
+    let totalPlayTime: (Player) -> TimeInterval
     let onPlayerTap: (Player) -> Void
     let onActivatePlayer: (Player) -> Void
     let onReorder: (([Player]) -> Void)?
@@ -90,6 +91,7 @@ struct BenchSectionView: View {
     private func playerRow(player: Player, index: Int) -> some View {
         BenchPlayerRowView(
             player: player,
+            totalPlayTime: totalPlayTime(player),
             isNextUp: index == 0,
             canActivate: canActivate,
             onTap: { onPlayerTap(player) },
@@ -116,14 +118,16 @@ struct BenchSectionView: View {
 // MARK: - Preview
 
 #Preview("With Bench Players") {
+    let totals: [String: TimeInterval] = ["John Doe": 180, "Jane Smith": 240, "Mike Johnson": 120]
     BenchSectionView(
         players: [
-            Player(name: "John Doe", totalPlayTime: 180, status: .benched),
-            Player(name: "Jane Smith", totalPlayTime: 240, status: .benched),
-            Player(name: "Mike Johnson", totalPlayTime: 120, status: .benched)
+            Player(name: "John Doe", status: .benched),
+            Player(name: "Jane Smith", status: .benched),
+            Player(name: "Mike Johnson", status: .benched)
         ],
         activePlayersCount: 4,
         maxActiveCount: 4,
+        totalPlayTime: { totals[$0.name] ?? 0 },
         onPlayerTap: { player in print("Tapped: \(player.name)") },
         onActivatePlayer: { player in print("Activate: \(player.name)") },
         onReorder: { players in print("Reordered: \(players.map { $0.name })") }
@@ -136,6 +140,7 @@ struct BenchSectionView: View {
         players: [],
         activePlayersCount: 4,
         maxActiveCount: 4,
+        totalPlayTime: { _ in 0 },
         onPlayerTap: { _ in },
         onActivatePlayer: { _ in },
         onReorder: nil
@@ -144,13 +149,15 @@ struct BenchSectionView: View {
 }
 
 #Preview("Can Activate") {
+    let totals: [String: TimeInterval] = ["John Doe": 180, "Jane Smith": 240]
     BenchSectionView(
         players: [
-            Player(name: "John Doe", totalPlayTime: 180, status: .benched),
-            Player(name: "Jane Smith", totalPlayTime: 240, status: .benched)
+            Player(name: "John Doe", status: .benched),
+            Player(name: "Jane Smith", status: .benched)
         ],
         activePlayersCount: 2,
         maxActiveCount: 4,
+        totalPlayTime: { totals[$0.name] ?? 0 },
         onPlayerTap: { _ in },
         onActivatePlayer: { _ in },
         onReorder: { _ in print("Reordered") }
@@ -159,13 +166,15 @@ struct BenchSectionView: View {
 }
 
 #Preview("Cannot Activate") {
+    let totals: [String: TimeInterval] = ["John Doe": 180, "Jane Smith": 240]
     BenchSectionView(
         players: [
-            Player(name: "John Doe", totalPlayTime: 180, status: .benched),
-            Player(name: "Jane Smith", totalPlayTime: 240, status: .benched)
+            Player(name: "John Doe", status: .benched),
+            Player(name: "Jane Smith", status: .benched)
         ],
         activePlayersCount: 4,
         maxActiveCount: 4,
+        totalPlayTime: { totals[$0.name] ?? 0 },
         onPlayerTap: { _ in },
         onActivatePlayer: { _ in },
         onReorder: nil
@@ -176,10 +185,11 @@ struct BenchSectionView: View {
 #Preview("Single Bench Player") {
     BenchSectionView(
         players: [
-            Player(name: "Solo Benched", totalPlayTime: 60, status: .benched)
+            Player(name: "Solo Benched", status: .benched)
         ],
         activePlayersCount: 3,
         maxActiveCount: 4,
+        totalPlayTime: { _ in 60 },
         onPlayerTap: { _ in },
         onActivatePlayer: { _ in },
         onReorder: nil

--- a/SubTimer/Views/Components/Players/TemporarilyOutPlayerRowView.swift
+++ b/SubTimer/Views/Components/Players/TemporarilyOutPlayerRowView.swift
@@ -12,6 +12,7 @@ struct TemporarilyOutPlayerRowView: View {
     // MARK: - Properties
 
     let player: Player
+    let totalPlayTime: TimeInterval
     let onReturnToBench: () -> Void
 
     // MARK: - Body
@@ -21,7 +22,7 @@ struct TemporarilyOutPlayerRowView: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(player.name)
                     .font(.headline)
-                Text("Total: \(TimeFormatter.format(player.totalPlayTime))")
+                Text("Total: \(TimeFormatter.format(totalPlayTime))")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
@@ -52,7 +53,8 @@ struct TemporarilyOutPlayerRowView: View {
 
 #Preview("Temporarily Out Player") {
     TemporarilyOutPlayerRowView(
-        player: Player(name: "John Doe", totalPlayTime: 300),
+        player: Player(name: "John Doe"),
+        totalPlayTime: 300,
         onReturnToBench: { print("Return to bench tapped") }
     )
     .padding()
@@ -60,7 +62,8 @@ struct TemporarilyOutPlayerRowView: View {
 
 #Preview("High Play Time") {
     TemporarilyOutPlayerRowView(
-        player: Player(name: "Jane Smith", totalPlayTime: 600),
+        player: Player(name: "Jane Smith"),
+        totalPlayTime: 600,
         onReturnToBench: { print("Return to bench tapped") }
     )
     .padding()
@@ -68,7 +71,8 @@ struct TemporarilyOutPlayerRowView: View {
 
 #Preview("Low Play Time") {
     TemporarilyOutPlayerRowView(
-        player: Player(name: "Mike Johnson", totalPlayTime: 30),
+        player: Player(name: "Mike Johnson"),
+        totalPlayTime: 30,
         onReturnToBench: { print("Return to bench tapped") }
     )
     .padding()
@@ -76,7 +80,8 @@ struct TemporarilyOutPlayerRowView: View {
 
 #Preview("Zero Play Time") {
     TemporarilyOutPlayerRowView(
-        player: Player(name: "New Player", totalPlayTime: 0),
+        player: Player(name: "New Player"),
+        totalPlayTime: 0,
         onReturnToBench: { print("Return to bench tapped") }
     )
     .padding()

--- a/SubTimer/Views/Components/Players/TemporarilyOutSectionView.swift
+++ b/SubTimer/Views/Components/Players/TemporarilyOutSectionView.swift
@@ -12,6 +12,7 @@ struct TemporarilyOutSectionView: View {
     // MARK: - Properties
 
     let players: [Player]
+    let totalPlayTime: (Player) -> TimeInterval
     let onReturnToBench: (Player) -> Void
 
     // MARK: - Body
@@ -29,6 +30,7 @@ struct TemporarilyOutSectionView: View {
                 ForEach(players) { player in
                     TemporarilyOutPlayerRowView(
                         player: player,
+                        totalPlayTime: totalPlayTime(player),
                         onReturnToBench: { onReturnToBench(player) }
                     )
                     .padding(.horizontal, 4)
@@ -44,12 +46,14 @@ struct TemporarilyOutSectionView: View {
 // MARK: - Preview
 
 #Preview("With Temporarily Out Players") {
+    let totals: [String: TimeInterval] = ["John Doe": 300, "Jane Smith": 450, "Mike Johnson": 180]
     TemporarilyOutSectionView(
         players: [
-            Player(name: "John Doe", totalPlayTime: 300, status: .temporarilyOut),
-            Player(name: "Jane Smith", totalPlayTime: 450, status: .temporarilyOut),
-            Player(name: "Mike Johnson", totalPlayTime: 180, status: .temporarilyOut)
+            Player(name: "John Doe", status: .temporarilyOut),
+            Player(name: "Jane Smith", status: .temporarilyOut),
+            Player(name: "Mike Johnson", status: .temporarilyOut)
         ],
+        totalPlayTime: { totals[$0.name] ?? 0 },
         onReturnToBench: { player in print("Return: \(player.name)") }
     )
     .padding()
@@ -58,21 +62,24 @@ struct TemporarilyOutSectionView: View {
 #Preview("Single Player") {
     TemporarilyOutSectionView(
         players: [
-            Player(name: "Solo Out", totalPlayTime: 200, status: .temporarilyOut)
+            Player(name: "Solo Out", status: .temporarilyOut)
         ],
+        totalPlayTime: { _ in 200 },
         onReturnToBench: { _ in }
     )
     .padding()
 }
 
 #Preview("Multiple Players") {
+    let totals: [String: TimeInterval] = ["Player 1": 100, "Player 2": 500, "Player 3": 250, "Player 4": 75]
     TemporarilyOutSectionView(
         players: [
-            Player(name: "Player 1", totalPlayTime: 100, status: .temporarilyOut),
-            Player(name: "Player 2", totalPlayTime: 500, status: .temporarilyOut),
-            Player(name: "Player 3", totalPlayTime: 250, status: .temporarilyOut),
-            Player(name: "Player 4", totalPlayTime: 75, status: .temporarilyOut)
+            Player(name: "Player 1", status: .temporarilyOut),
+            Player(name: "Player 2", status: .temporarilyOut),
+            Player(name: "Player 3", status: .temporarilyOut),
+            Player(name: "Player 4", status: .temporarilyOut)
         ],
+        totalPlayTime: { totals[$0.name] ?? 0 },
         onReturnToBench: { _ in }
     )
     .padding()
@@ -81,8 +88,9 @@ struct TemporarilyOutSectionView: View {
 #Preview("Zero Play Time") {
     TemporarilyOutSectionView(
         players: [
-            Player(name: "New Player Out", totalPlayTime: 0, status: .temporarilyOut)
+            Player(name: "New Player Out", status: .temporarilyOut)
         ],
+        totalPlayTime: { _ in 0 },
         onReturnToBench: { _ in }
     )
     .padding()

--- a/SubTimer/Views/Components/Timer/PlayerActionsSheetView.swift
+++ b/SubTimer/Views/Components/Timer/PlayerActionsSheetView.swift
@@ -12,6 +12,9 @@ struct PlayerActionsSheetView: View {
     // MARK: - Properties
 
     let player: Player
+    let status: RotationBucket
+    let currentPlayDuration: TimeInterval
+    let totalPlayTime: TimeInterval
     let canActivate: Bool
     let onSubstituteOut: () -> Void
     let onActivatePlayer: () -> Void
@@ -26,11 +29,11 @@ struct PlayerActionsSheetView: View {
             List {
                 // Actions section based on player status
                 Section {
-                    if player.status == .active {
+                    if status == .active {
                         activePlayerActions
-                    } else if player.status == .benched {
+                    } else if status == .benched {
                         benchedPlayerActions
-                    } else if player.status == .temporarilyOut {
+                    } else if status == .temporarilyOut {
                         temporarilyOutPlayerActions
                     }
                 }
@@ -99,14 +102,14 @@ struct PlayerActionsSheetView: View {
             HStack {
                 Text("Current Play Duration")
                 Spacer()
-                Text(TimeFormatter.format(player.currentPlayDuration))
+                Text(TimeFormatter.format(currentPlayDuration))
                     .foregroundStyle(.secondary)
             }
 
             HStack {
                 Text("Total Play Time")
                 Spacer()
-                Text(TimeFormatter.format(player.totalPlayTime))
+                Text(TimeFormatter.format(totalPlayTime))
                     .foregroundStyle(.secondary)
             }
         }
@@ -117,13 +120,10 @@ struct PlayerActionsSheetView: View {
 
 #Preview("Active Player") {
     PlayerActionsSheetView(
-        player: Player(
-            name: "Alice",
-            currentPlayDuration: 120, // 2 minutes
-            totalPlayTime: 600, // 10 minutes
-            status: .active,
-            sortOrder: 0
-        ),
+        player: Player(name: "Alice", sortOrder: 0),
+        status: .active,
+        currentPlayDuration: 120, // 2 minutes
+        totalPlayTime: 600, // 10 minutes
         canActivate: true,
         onSubstituteOut: { print("Substitute out") },
         onActivatePlayer: { print("Activate") },
@@ -135,13 +135,10 @@ struct PlayerActionsSheetView: View {
 
 #Preview("Benched Player - Can Activate") {
     PlayerActionsSheetView(
-        player: Player(
-            name: "Bob",
-            currentPlayDuration: 0,
-            totalPlayTime: 450, // 7.5 minutes
-            status: .benched,
-            sortOrder: 1
-        ),
+        player: Player(name: "Bob", sortOrder: 1),
+        status: .benched,
+        currentPlayDuration: 0,
+        totalPlayTime: 450, // 7.5 minutes
         canActivate: true,
         onSubstituteOut: { print("Substitute out") },
         onActivatePlayer: { print("Activate") },
@@ -153,13 +150,10 @@ struct PlayerActionsSheetView: View {
 
 #Preview("Benched Player - Cannot Activate") {
     PlayerActionsSheetView(
-        player: Player(
-            name: "Charlie",
-            currentPlayDuration: 0,
-            totalPlayTime: 300, // 5 minutes
-            status: .benched,
-            sortOrder: 2
-        ),
+        player: Player(name: "Charlie", sortOrder: 2),
+        status: .benched,
+        currentPlayDuration: 0,
+        totalPlayTime: 300, // 5 minutes
         canActivate: false,
         onSubstituteOut: { print("Substitute out") },
         onActivatePlayer: { print("Activate") },
@@ -171,13 +165,10 @@ struct PlayerActionsSheetView: View {
 
 #Preview("Temporarily Out Player") {
     PlayerActionsSheetView(
-        player: Player(
-            name: "Diana",
-            currentPlayDuration: 0,
-            totalPlayTime: 800, // 13.3 minutes
-            status: .temporarilyOut,
-            sortOrder: 3
-        ),
+        player: Player(name: "Diana", sortOrder: 3),
+        status: .temporarilyOut,
+        currentPlayDuration: 0,
+        totalPlayTime: 800, // 13.3 minutes
         canActivate: false,
         onSubstituteOut: { print("Substitute out") },
         onActivatePlayer: { print("Activate") },
@@ -189,13 +180,10 @@ struct PlayerActionsSheetView: View {
 
 #Preview("Player with No Play Time") {
     PlayerActionsSheetView(
-        player: Player(
-            name: "Eve",
-            currentPlayDuration: 0,
-            totalPlayTime: 0,
-            status: .benched,
-            sortOrder: 4
-        ),
+        player: Player(name: "Eve", sortOrder: 4),
+        status: .benched,
+        currentPlayDuration: 0,
+        totalPlayTime: 0,
         canActivate: true,
         onSubstituteOut: { print("Substitute out") },
         onActivatePlayer: { print("Activate") },

--- a/SubTimer/Views/TimerView.swift
+++ b/SubTimer/Views/TimerView.swift
@@ -550,7 +550,16 @@ extension TimerView {
         let now = Date()
         for index in 0..<playersToActivate where index < allFilteredPlayers.count {
             let player = allFilteredPlayers[index]
-            try? gameManager.transition(playerId: player.id, to: .active, in: game)
+            do {
+                try gameManager.transition(playerId: player.id, to: .active, in: game)
+            } catch {
+                // `player` was just pulled from this same context's query results, so
+                // `playerNotFound` here would mean a real programming bug, not a
+                // recoverable runtime state.
+                assertionFailure(
+                    "GameManager.transition failed for a player already resolved from the context: \(error)"
+                )
+            }
             player.status = .active
             player.activatedAtDate = now
             player.currentPlayDuration = 0
@@ -621,7 +630,17 @@ extension TimerView {
         // the swap into Game/Stint here, so the Game-derived duration values
         // (see PlayerActionsSheetView/row views) stay correct in the interim.
         if let game = currentGame {
-            try? gameManager.manualSubstitution(outgoing: subOut.id, incoming: subIn.id, game: game)
+            do {
+                try gameManager.manualSubstitution(outgoing: subOut.id, incoming: subIn.id, game: game)
+            } catch {
+                // Unlike the transition() sites above, the legacy path and this mirror
+                // aren't the same call, so a throw here is a real drift signal between
+                // Player.status/OrderManager and Game/Stint, not just a defensive check.
+                assertionFailure(
+                    "GameManager.manualSubstitution mirror failed, Game/Stint state has drifted from legacy path: "
+                        + "\(error)"
+                )
+            }
         }
 
         if let activeSession = sessions.first(where: { $0.isActive }) {
@@ -650,7 +669,11 @@ extension TimerView {
 
     func activatePlayer(_ player: Player) {
         guard let game = currentGame else { return }
-        try? gameManager.transition(playerId: player.id, to: .active, in: game)
+        do {
+            try gameManager.transition(playerId: player.id, to: .active, in: game)
+        } catch {
+            assertionFailure("GameManager.transition failed for a player already resolved from the context: \(error)")
+        }
 
         player.status = .active
         player.activatedAtDate = Date()

--- a/SubTimer/Views/TimerView.swift
+++ b/SubTimer/Views/TimerView.swift
@@ -98,12 +98,13 @@ struct TimerView: View {
     @Query private var configurations: [AppConfiguration]
     @Query(sort: \Session.startDate, order: .reverse) var sessions: [Session]
     @Query private var orderManagers: [OrderManager]
+    @Query private var teams: [Team]
+    @Query private var games: [Game]
 
     @State var timerViewModel: TimerViewModel?
     @State private var activeSheet: TimerSheet?
-    @State private var benchOrder: [UUID] = []
-    @State private var activeOrder: [UUID] = []
     @State private var cachedManagers: [PlayerOrderRole: OrderManager] = [:]
+    @State private var currentGame: Game?
     @State private var showPinnedButton = false
     @State private var overtimeUpdateWork: DispatchWorkItem?
     @State private var showCompactTimer = false
@@ -117,6 +118,26 @@ struct TimerView: View {
             return newConfig
         }
     }
+
+    /// The app's one auto-created `Team` (per #59's migration guarantee) —
+    /// lazily created here to also cover installs where migration never ran
+    /// (a fresh install, or `--uitesting`'s in-memory fixture store), since
+    /// neither of those goes through `SchemaMigrationPlan`.
+    var team: Team {
+        if let existing = teams.first {
+            return existing
+        }
+        let newTeam = Team(
+            name: "",
+            sport: "",
+            preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
+            activePlayersCount: configuration.activePlayersCount
+        )
+        modelContext.insert(newTeam)
+        return newTeam
+    }
+
+    var gameManager: GameManager { GameManager(context: modelContext) }
 
     func orderManager(for role: PlayerOrderRole) -> OrderManager {
         if let cached = cachedManagers[role] {
@@ -140,15 +161,12 @@ struct TimerView: View {
     var activeManager: OrderManager { orderManager(for: .active) }
 
     var activePlayers: [Player] {
-        let active = players.filter { $0.status == .active }
-
-        let orderToUse = activeOrder.isEmpty
-            ? (orderManagers.first(where: { $0.role == .active })?.playerOrder ?? [])
-            : activeOrder
+        guard let game = currentGame else { return [] }
+        let active = players.filter { gameManager.status(playerId: $0.id, in: game) == .active }
 
         return active.sorted { player1, player2 in
-            let pos1 = orderToUse.firstIndex(of: player1.id)
-            let pos2 = orderToUse.firstIndex(of: player2.id)
+            let pos1 = game.activeOrder.firstIndex(of: player1.id)
+            let pos2 = game.activeOrder.firstIndex(of: player2.id)
 
             if let pos1, let pos2 {
                 return pos1 < pos2
@@ -157,23 +175,19 @@ struct TimerView: View {
             } else if pos2 != nil {
                 return false
             } else {
-                return player1.currentPlayDuration > player2.currentPlayDuration
+                return gameManager.currentPlayDuration(playerId: player1.id, in: game)
+                    > gameManager.currentPlayDuration(playerId: player2.id, in: game)
             }
         }
     }
 
     var benchedPlayers: [Player] {
-        let benched = players.filter { $0.status == .benched }
+        guard let game = currentGame else { return [] }
+        let benched = players.filter { gameManager.status(playerId: $0.id, in: game) == .benched }
 
-        // Use the state-managed bench order for immediate UI updates
-        let orderToUse = benchOrder.isEmpty
-            ? (orderManagers.first(where: { $0.role == .bench })?.playerOrder ?? [])
-            : benchOrder
-
-        // Sort by bench order, then by sortOrder for players not in the bench order
         return benched.sorted { player1, player2 in
-            let pos1 = orderToUse.firstIndex(of: player1.id)
-            let pos2 = orderToUse.firstIndex(of: player2.id)
+            let pos1 = game.benchOrder.firstIndex(of: player1.id)
+            let pos2 = game.benchOrder.firstIndex(of: player2.id)
 
             if let pos1, let pos2 {
                 return pos1 < pos2
@@ -187,8 +201,13 @@ struct TimerView: View {
         }
     }
 
+    /// `Game.temporarilyOut` is an unordered `Set`, so this relies on
+    /// `players` already being `@Query(sort: \Player.sortOrder)` for a
+    /// stable, roster-order display - matching this section's old
+    /// `Player.status`-filtered behavior exactly.
     var temporarilyOutPlayers: [Player] {
-        players.filter { $0.status == .temporarilyOut }
+        guard let game = currentGame else { return [] }
+        return players.filter { gameManager.status(playerId: $0.id, in: game) == .temporarilyOut }
     }
 
     var body: some View {
@@ -206,10 +225,7 @@ struct TimerView: View {
                 _ = benchManager
                 _ = activeManager
                 initializeViewModel(allPlayers: players)
-                syncOrderManager(role: .bench, status: .benched)
-                syncOrderManager(role: .active, status: .active)
-                loadOrder(for: .bench)
-                loadOrder(for: .active)
+                resolveOrCreateGame()
             }
             .sheet(item: $activeSheet) { sheet in
                 switch sheet {
@@ -348,6 +364,7 @@ struct TimerView: View {
         ActivePlayersSectionView(
             players: activePlayers,
             maxActiveCount: configuration.activePlayersCount,
+            currentPlayDuration: { resolvedCurrentPlayDuration(for: $0) },
             onPlayerTap: { player in activeSheet = .playerActions(player) },
             onReorder: { self.reorderPlayers($0, role: .active) }
         )
@@ -360,6 +377,7 @@ struct TimerView: View {
             players: benchedPlayers,
             activePlayersCount: activePlayers.count,
             maxActiveCount: configuration.activePlayersCount,
+            totalPlayTime: { resolvedTotalPlayTime(for: $0) },
             onPlayerTap: { player in activeSheet = .playerActions(player) },
             onActivatePlayer: activatePlayer,
             onReorder: { self.reorderPlayers($0, role: .bench) }
@@ -371,8 +389,23 @@ struct TimerView: View {
     private var temporarilyOutSection: some View {
         TemporarilyOutSectionView(
             players: temporarilyOutPlayers,
+            totalPlayTime: { resolvedTotalPlayTime(for: $0) },
             onReturnToBench: returnPlayerToBench
         )
+    }
+
+    /// `GameManager.currentPlayDuration`/`totalPlayTime` resolved for a
+    /// single `player`, so section/row views receive display values as
+    /// parameters instead of reading `Player.currentPlayDuration`/
+    /// `totalPlayTime` directly (see issue #60).
+    private func resolvedCurrentPlayDuration(for player: Player) -> TimeInterval {
+        guard let game = currentGame else { return 0 }
+        return gameManager.currentPlayDuration(playerId: player.id, in: game)
+    }
+
+    private func resolvedTotalPlayTime(for player: Player) -> TimeInterval {
+        guard let game = currentGame else { return 0 }
+        return gameManager.totalPlayTime(playerId: player.id, in: game)
     }
 
     // MARK: - Substitute Button
@@ -406,8 +439,12 @@ struct TimerView: View {
     // MARK: - Player Actions Sheet
 
     private func playerActionsSheet(player: Player) -> some View {
-        PlayerActionsSheetView(
+        let status = currentGame.map { gameManager.status(playerId: player.id, in: $0) } ?? .benched
+        return PlayerActionsSheetView(
             player: player,
+            status: status,
+            currentPlayDuration: resolvedCurrentPlayDuration(for: player),
+            totalPlayTime: resolvedTotalPlayTime(for: player),
             canActivate: activePlayers.count < configuration.activePlayersCount,
             onSubstituteOut: {
                 activeSheet = .manualSubstitution(playerToSubOut: player)
@@ -445,45 +482,45 @@ extension TimerView {
         timerViewModel?.onTimerTick = { updatePlayerTimes() }
     }
 
-    /// Syncs a role-scoped order (players is already `@Query(sort: \Player.sortOrder)`,
-    /// so filtering it preserves roster order) against current player statuses: adds
-    /// players missing from the order, drops ones that changed status.
-    func syncOrderManager(role: PlayerOrderRole, status: PlayerStatus) {
-        let manager = orderManager(for: role)
-        let currentPlayers = players.filter { $0.status == status }
+    /// Resolves `currentGame` to the `Team`'s open `Game` (no `endDate` yet),
+    /// or creates one. A fresh `Game` only exists here (no open `Game` found)
+    /// in two cases: a real user's very first launch after this ticket ships
+    /// (migration only produces closed, historical `Game`s from old
+    /// `Session`s - never an open one), or the `--uitesting` fixture launch
+    /// (no `Team`/`Game` at all). `GameManager.seedFromLegacyStatus` bridges
+    /// both by carrying the current `Player.status`-driven state into the
+    /// new `Game` exactly once, at creation.
+    func resolveOrCreateGame() {
+        guard currentGame == nil else { return }
+        let resolvedTeam = team
 
-        for player in currentPlayers where manager.position(of: player.id) == nil {
-            manager.addPlayer(player.id)
+        if let openGame = games.first(where: { $0.team?.id == resolvedTeam.id && $0.endDate == nil }) {
+            currentGame = openGame
+            return
         }
 
-        let currentIds = Set(currentPlayers.map { $0.id })
-        manager.playerOrder.removeAll { !currentIds.contains($0) }
-        manager.updatedDate = Date()
-    }
-
-    func loadOrder(for role: PlayerOrderRole) {
-        switch role {
-        case .bench:
-            benchOrder = orderManager(for: role).playerOrder
-        case .active:
-            activeOrder = orderManager(for: role).playerOrder
-        }
+        let newGame = Game(
+            preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
+            activePlayersCount: configuration.activePlayersCount,
+            team: resolvedTeam
+        )
+        modelContext.insert(newGame)
+        let snapshot = LegacyRotationSnapshot(
+            activePlayers: players.filter { $0.status == .active },
+            benchedPlayers: players.filter { $0.status == .benched },
+            temporarilyOutPlayers: players.filter { $0.status == .temporarilyOut },
+            existingActiveOrder: activeManager.playerOrder,
+            existingBenchOrder: benchManager.playerOrder
+        )
+        gameManager.seedFromLegacyStatus(snapshot, in: newGame)
+        currentGame = newGame
     }
 
     func reorderPlayers(_ reorderedPlayers: [Player], role: PlayerOrderRole) {
+        guard let game = currentGame else { return }
         let newOrder = reorderedPlayers.map { $0.id }
-
-        switch role {
-        case .bench:
-            benchOrder = newOrder
-        case .active:
-            activeOrder = newOrder
-        }
-
-        let manager = orderManager(for: role)
-        manager.playerOrder.removeAll()
-        manager.playerOrder.append(contentsOf: newOrder)
-        manager.updatedDate = Date()
+        let bucket: RotationBucket = role == .active ? .active : .benched
+        gameManager.setOrder(newOrder, for: bucket, in: game)
     }
 
     func toggleTimer() {
@@ -507,17 +544,17 @@ extension TimerView {
     }
 
     private func autoActivateInitialPlayersIfNeeded() {
-        guard activePlayers.isEmpty else { return }
+        guard let game = currentGame, activePlayers.isEmpty else { return }
         let allFilteredPlayers = activePlayers + benchedPlayers + temporarilyOutPlayers
         let playersToActivate = min(configuration.activePlayersCount, allFilteredPlayers.count)
         let now = Date()
         for index in 0..<playersToActivate where index < allFilteredPlayers.count {
-            allFilteredPlayers[index].status = .active
-            allFilteredPlayers[index].activatedAtDate = now
-            allFilteredPlayers[index].currentPlayDuration = 0
-            activeManager.addPlayer(allFilteredPlayers[index].id)
+            let player = allFilteredPlayers[index]
+            try? gameManager.transition(playerId: player.id, to: .active, in: game)
+            player.status = .active
+            player.activatedAtDate = now
+            player.currentPlayDuration = 0
         }
-        activeOrder = activeManager.playerOrder
     }
 
     private func updatePlayerTimes() {
@@ -575,11 +612,17 @@ extension TimerView {
 
         benchManager.removePlayer(subIn.id)
         benchManager.addPlayer(subOut.id)
-        benchOrder = benchManager.playerOrder
 
         activeManager.removePlayer(subOut.id)
         activeManager.addPlayer(subIn.id)
-        activeOrder = activeManager.playerOrder
+
+        // Substitution stays on the Player.status/OrderManager path above
+        // (rewiring it fully onto GameManager is #61's job) but also mirrors
+        // the swap into Game/Stint here, so the Game-derived duration values
+        // (see PlayerActionsSheetView/row views) stay correct in the interim.
+        if let game = currentGame {
+            try? gameManager.manualSubstitution(outgoing: subOut.id, incoming: subIn.id, game: game)
+        }
 
         if let activeSession = sessions.first(where: { $0.isActive }) {
             activeSession.substitutionCount += 1
@@ -598,32 +641,41 @@ extension TimerView {
         }
     }  // MARK: - Player Status
 
+    // Activate/mark-temporarily-out/return-to-bench read/write Game via
+    // GameManager exclusively now (issue #60) - the Player.status write in
+    // each is a display-only mirror for SettingsView, which still reads
+    // Player.status directly until #62 rewires it onto TeamManager/Game;
+    // TimerView itself never reads these three fields back. Tracked as
+    // tech debt to remove in #62 alongside Player.status's deletion.
+
     func activatePlayer(_ player: Player) {
+        guard let game = currentGame else { return }
+        try? gameManager.transition(playerId: player.id, to: .active, in: game)
+
         player.status = .active
         player.activatedAtDate = Date()
         player.currentPlayDuration = 0
-        benchManager.removePlayer(player.id)
-        benchOrder = benchManager.playerOrder
-        activeManager.addPlayer(player.id)
-        activeOrder = activeManager.playerOrder
         updateLiveActivity()
     }
 
     func markPlayerTemporarilyOut(_ player: Player) {
-        if player.status == .active {
+        guard let game = currentGame else { return }
+        let wasActive = gameManager.status(playerId: player.id, in: game) == .active
+        try? gameManager.transition(playerId: player.id, to: .temporarilyOut, in: game)
+
+        if wasActive {
             let timePlayedThisSegment = Date().timeIntervalSince(player.activatedAtDate)
             player.totalPlayTime += timePlayedThisSegment
-            activeManager.removePlayer(player.id)
-            activeOrder = activeManager.playerOrder
         }
         player.status = .temporarilyOut
         updateLiveActivity()
     }
 
     func returnPlayerToBench(_ player: Player) {
+        guard let game = currentGame else { return }
+        try? gameManager.transition(playerId: player.id, to: .benched, in: game)
+
         player.status = .benched
-        benchManager.addPlayer(player.id)
-        benchOrder = benchManager.playerOrder
         updateLiveActivity()
     }
 
@@ -721,9 +773,17 @@ extension TimerView {
     }
 }
 
+/// Registers the full app schema (see `SchemaV2.models`) so `TimerView`'s
+/// `@Query`s for `OrderManager`/`Team`/`Game`/`Stint` don't crash at preview
+/// render time.
+private let previewSchemaModels: [any PersistentModel.Type] = [
+    Player.self, AppConfiguration.self, Session.self, OrderManager.self,
+    Team.self, RosterMembership.self, Game.self, Stint.self
+]
+
 #Preview("Empty State") {
     TimerView()
-        .modelContainer(for: [Player.self, AppConfiguration.self, Session.self], inMemory: true)
+        .modelContainer(for: previewSchemaModels, inMemory: true)
 }
 
 /// Preview providers are compile-time-only and never execute in a shipped
@@ -733,7 +793,7 @@ extension TimerView {
 private func makeMainTimerPreviewContainer() -> ModelContainer {
     // swiftlint:disable:next force_try
     let container = try! ModelContainer(
-        for: Player.self, AppConfiguration.self, Session.self,
+        for: Schema(previewSchemaModels),
         configurations: ModelConfiguration(isStoredInMemoryOnly: true)
     )
 
@@ -749,14 +809,17 @@ private func makeMainTimerPreviewContainer() -> ModelContainer {
     let player1 = Player(name: "Alice", sortOrder: 0)
     player1.status = .active
     player1.currentPlayDuration = 120
+    player1.activatedAtDate = Date().addingTimeInterval(-120)
 
     let player2 = Player(name: "Bob", sortOrder: 1)
     player2.status = .active
     player2.currentPlayDuration = 95
+    player2.activatedAtDate = Date().addingTimeInterval(-95)
 
     let player3 = Player(name: "Charlie", sortOrder: 2)
     player3.status = .active
     player3.currentPlayDuration = 110
+    player3.activatedAtDate = Date().addingTimeInterval(-110)
 
     let player4 = Player(name: "Diana", sortOrder: 3)
     player4.status = .benched

--- a/SubTimerTests/GameManagerStatusAndOrderTests.swift
+++ b/SubTimerTests/GameManagerStatusAndOrderTests.swift
@@ -1,0 +1,230 @@
+//
+//  GameManagerStatusAndOrderTests.swift
+//  SubTimerTests
+//
+//  Created by SubTimer on 8/18/26.
+//
+
+import Foundation
+@testable import SubTimer
+import SwiftData
+import Testing
+
+private func makeGameManagerTestContext() throws -> ModelContext {
+    let schema = Schema([Player.self, Team.self, RosterMembership.self, Game.self, Stint.self])
+    let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+    let container = try ModelContainer(for: schema, configurations: [configuration])
+    return ModelContext(container)
+}
+
+struct GameManagerStatusAndOrderTests {
+    @Test func statusReturnsActiveForPlayerInActiveOrder() throws {
+        let context = try makeGameManagerTestContext()
+        let player = Player(name: "Alex")
+        let game = Game(activeOrder: [player.id])
+        context.insert(player)
+        context.insert(game)
+        let manager = GameManager(context: context)
+
+        #expect(manager.status(playerId: player.id, in: game) == .active)
+    }
+
+    @Test func statusReturnsTemporarilyOutForPlayerInTemporarilyOutSet() throws {
+        let context = try makeGameManagerTestContext()
+        let player = Player(name: "Alex")
+        let game = Game(temporarilyOut: [player.id])
+        context.insert(player)
+        context.insert(game)
+        let manager = GameManager(context: context)
+
+        #expect(manager.status(playerId: player.id, in: game) == .temporarilyOut)
+    }
+
+    @Test func statusReturnsBenchedForPlayerInBenchOrder() throws {
+        let context = try makeGameManagerTestContext()
+        let player = Player(name: "Alex")
+        let game = Game(benchOrder: [player.id])
+        context.insert(player)
+        context.insert(game)
+        let manager = GameManager(context: context)
+
+        #expect(manager.status(playerId: player.id, in: game) == .benched)
+    }
+
+    @Test func statusDefaultsToBenchedForPlayerInNoBucket() throws {
+        let context = try makeGameManagerTestContext()
+        let player = Player(name: "Alex")
+        let game = Game()
+        context.insert(player)
+        context.insert(game)
+        let manager = GameManager(context: context)
+
+        #expect(manager.status(playerId: player.id, in: game) == .benched)
+    }
+
+    @Test func setOrderReplacesActiveOrderWithoutChangingMembership() throws {
+        let context = try makeGameManagerTestContext()
+        let playerA = Player(name: "A")
+        let playerB = Player(name: "B")
+        let game = Game(activeOrder: [playerA.id, playerB.id])
+        context.insert(playerA)
+        context.insert(playerB)
+        context.insert(game)
+        let manager = GameManager(context: context)
+
+        manager.setOrder([playerB.id, playerA.id], for: .active, in: game)
+
+        #expect(game.activeOrder == [playerB.id, playerA.id])
+    }
+
+    @Test func setOrderReplacesBenchOrderWithoutChangingMembership() throws {
+        let context = try makeGameManagerTestContext()
+        let playerA = Player(name: "A")
+        let playerB = Player(name: "B")
+        let game = Game(benchOrder: [playerA.id, playerB.id])
+        context.insert(playerA)
+        context.insert(playerB)
+        context.insert(game)
+        let manager = GameManager(context: context)
+
+        manager.setOrder([playerB.id, playerA.id], for: .benched, in: game)
+
+        #expect(game.benchOrder == [playerB.id, playerA.id])
+    }
+
+    @Test func setOrderIsNoOpForTemporarilyOut() throws {
+        let context = try makeGameManagerTestContext()
+        let player = Player(name: "Alex")
+        let game = Game(temporarilyOut: [player.id])
+        context.insert(player)
+        context.insert(game)
+        let manager = GameManager(context: context)
+
+        manager.setOrder([player.id], for: .temporarilyOut, in: game)
+
+        #expect(game.temporarilyOut == [player.id])
+    }
+
+    @Test func seedFromLegacyStatusSeedsBucketMembership() throws {
+        let context = try makeGameManagerTestContext()
+        let active = Player(name: "Active")
+        let benched = Player(name: "Benched")
+        let tempOut = Player(name: "TempOut")
+        let game = Game()
+        context.insert(active)
+        context.insert(benched)
+        context.insert(tempOut)
+        context.insert(game)
+        let manager = GameManager(context: context)
+
+        manager.seedFromLegacyStatus(
+            LegacyRotationSnapshot(
+                activePlayers: [active],
+                benchedPlayers: [benched],
+                temporarilyOutPlayers: [tempOut],
+                existingActiveOrder: [],
+                existingBenchOrder: []
+            ),
+            in: game
+        )
+
+        #expect(game.activeOrder == [active.id])
+        #expect(game.benchOrder == [benched.id])
+        #expect(game.temporarilyOut == [tempOut.id])
+    }
+
+    @Test func seedFromLegacyStatusPreservesExistingOrderManagerOrder() throws {
+        let context = try makeGameManagerTestContext()
+        let playerA = Player(name: "A")
+        let playerB = Player(name: "B")
+        let game = Game()
+        context.insert(playerA)
+        context.insert(playerB)
+        context.insert(game)
+        let manager = GameManager(context: context)
+
+        manager.seedFromLegacyStatus(
+            LegacyRotationSnapshot(
+                activePlayers: [playerA, playerB],
+                benchedPlayers: [],
+                temporarilyOutPlayers: [],
+                existingActiveOrder: [playerB.id, playerA.id],
+                existingBenchOrder: []
+            ),
+            in: game
+        )
+
+        #expect(game.activeOrder == [playerB.id, playerA.id])
+    }
+
+    @Test func seedFromLegacyStatusCarriesOverTotalPlayTimeForBenchedPlayer() throws {
+        let context = try makeGameManagerTestContext()
+        let benched = Player(name: "Benched", totalPlayTime: 180)
+        let game = Game()
+        context.insert(benched)
+        context.insert(game)
+        let manager = GameManager(context: context)
+
+        manager.seedFromLegacyStatus(
+            LegacyRotationSnapshot(
+                activePlayers: [],
+                benchedPlayers: [benched],
+                temporarilyOutPlayers: [],
+                existingActiveOrder: [],
+                existingBenchOrder: []
+            ),
+            in: game
+        )
+
+        let total = manager.totalPlayTime(playerId: benched.id, in: game)
+        #expect(abs(total - 180) < 0.01)
+    }
+
+    @Test func seedFromLegacyStatusCarriesOverBothPriorTotalAndCurrentSegmentForActivePlayer() throws {
+        let context = try makeGameManagerTestContext()
+        let now = Date()
+        let active = Player(name: "Active", totalPlayTime: 120, activatedAtDate: now.addingTimeInterval(-30))
+        let game = Game()
+        context.insert(active)
+        context.insert(game)
+        let manager = GameManager(context: context)
+
+        manager.seedFromLegacyStatus(
+            LegacyRotationSnapshot(
+                activePlayers: [active],
+                benchedPlayers: [],
+                temporarilyOutPlayers: [],
+                existingActiveOrder: [],
+                existingBenchOrder: []
+            ),
+            in: game
+        )
+
+        let currentDuration = manager.currentPlayDuration(playerId: active.id, in: game, now: now)
+        let total = manager.totalPlayTime(playerId: active.id, in: game, now: now)
+        #expect(abs(currentDuration - 30) < 0.01)
+        #expect(abs(total - 150) < 0.01)
+    }
+
+    @Test func seedFromLegacyStatusCreatesNoStintForPlayerWithNoPriorPlayTime() throws {
+        let context = try makeGameManagerTestContext()
+        let benched = Player(name: "Fresh")
+        let game = Game()
+        context.insert(benched)
+        context.insert(game)
+        let manager = GameManager(context: context)
+
+        manager.seedFromLegacyStatus(
+            LegacyRotationSnapshot(
+                activePlayers: [],
+                benchedPlayers: [benched],
+                temporarilyOutPlayers: [],
+                existingActiveOrder: [],
+                existingBenchOrder: []
+            ),
+            in: game
+        )
+
+        #expect((game.stints ?? []).isEmpty)
+    }
+}

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -6,8 +6,11 @@ The persisted model is mid-transition between two shapes:
   all current app behavior. Of these, `Player` continues to exist once the
   transition is complete; `Session`, `OrderManager`, and `AppConfiguration`
   are expected to be superseded by the dormant types below.
-- **Present but dormant:** `Team`, `RosterMembership`, `Game`, `Stint` —
-  declared in the schema; no app code reads or writes them yet.
+- **Partially in use:** `Team`, `RosterMembership`, `Game`, `Stint` —
+  `TimerView`'s activate/mark-temporarily-out/return-to-bench actions and
+  Active/Bench/Temporarily-Out section rendering read/write these via
+  `GameManager` (#60); `RosterMembership` and Substitution's own bucket/Stint
+  bookkeeping remain unread/unwritten by app UI until later tickets.
 
 ```mermaid
 classDiagram
@@ -181,3 +184,63 @@ sequenceDiagram
         Plan-->>App: migration complete
     end
 ```
+
+## TimerView rewired onto GameManager (#60)
+
+`TimerView`'s activate, mark-temporarily-out, and return-to-bench actions —
+plus Active/Bench/Temporarily-Out section rendering — now go through
+`GameManager` against an open `Game`, instead of `Player.status`/
+`OrderManager`. Two additions to `GameManager` support this:
+`status(playerId:in:) -> RotationBucket` (defaults to `.benched` when a
+player is in none of the three buckets, matching `Player.defaultStatus`) and
+`setOrder(_:for:in:)` (drag-to-reorder, replacing a bucket's order without
+changing membership — `.temporarilyOut` is a no-op, since it's an unordered
+`Set`).
+
+`TimerView` resolves-or-creates its `Game` eagerly, on `.onAppear`. A fresh
+`Game` is only created when no open one exists for the app's `Team` — for a
+real upgrading user, migration (#59) only produces closed, historical
+`Game`s, so a fresh `Game` is bootstrapped once from each player's current
+`Player.status`/`activatedAtDate`/`OrderManager` order, carrying an
+in-progress rotation into the new model without resetting it.
+
+Substitution (still out of scope for a full rewire until #61) keeps its
+existing `Player.status`/`OrderManager` writes, but also calls
+`GameManager.manualSubstitution` in parallel (for both the automatic and
+manual flows - `TimerView` already resolves the specific outgoing/incoming
+pair before either reaches this call, so there's no separate need for
+`GameManager.automaticSubstitution`'s own pairing logic here), so the
+`Game`/`Stint` state this ticket's display path depends on doesn't drift out
+of sync with a substitution performed through the old path. `activatePlayer`/
+`markPlayerTemporarilyOut`/`returnPlayerToBench` similarly keep a
+display-only `Player.status` mirror write (never read back by `TimerView`)
+purely so `SettingsView` — unrewired until #62 — doesn't show stale status;
+this mirror is tracked as tech debt to remove alongside `Player.status`'s
+deletion in #62.
+
+```mermaid
+sequenceDiagram
+    participant Coach
+    participant TimerView
+    participant GameManager
+    participant Game
+    participant Stint
+    participant Section as Active/Bench/TempOut SectionView
+
+    Coach->>TimerView: tap Activate / Mark Temporarily Out / Return to Bench
+    TimerView->>GameManager: transition(playerId, to: bucket, in: game)
+    GameManager->>Game: purge playerId from old bucket, insert into new bucket
+    GameManager->>Stint: close open Stint (leaving Active) or open new Stint (entering Active)
+    GameManager-->>TimerView: updated Game/Stint state
+
+    TimerView->>GameManager: status(playerId, in: game), currentPlayDuration/totalPlayTime(playerId, in: game)
+    GameManager-->>TimerView: resolved status + duration
+    TimerView->>Section: pass resolved status/duration as parameters
+    Section-->>Coach: renders - identical to today, no direct player.status/currentPlayDuration reads
+```
+
+Substitution stays on its existing path for its own display logic here — see
+#61 for the follow-on ticket that rewires Substitution and the Live Activity
+feed fully onto `GameManager`, at which point `Player.status`/
+`currentPlayDuration`/`totalPlayTime`/`OrderManager` will have no remaining
+references anywhere in `TimerView`.


### PR DESCRIPTION
## Summary

Closes #60.

Rewires `TimerView`'s activate, mark-temporarily-out, and return-to-bench actions — plus Active/Bench/Temporarily-Out section rendering — onto `GameManager` operating against `Game`/`Stint`, instead of `Player.status`/`OrderManager`. Zero visible UI change.

## What changed

- `GameManager` gains `status(playerId:in:) -> RotationBucket`, `setOrder(_:for:in:)` (drag-to-reorder), and `seedFromLegacyStatus(_:in:)` (one-time bootstrap for a freshly-created `Game`).
- `TimerView` resolves-or-creates an open `Game` for the app's `Team` eagerly on `.onAppear`. A fresh `Game` is only created when no open one exists (a real user's first launch on this version, or the `--uitesting` fixture path) and is bootstrapped from the current `Player.status`/`OrderManager`/`activatedAtDate` state — including historical `totalPlayTime` via synthetic closed `Stint`s — so an in-progress rotation carries over instead of resetting.
- `activatePlayer`/`markPlayerTemporarilyOut`/`returnPlayerToBench`/the timer's auto-activate-on-start path now call `GameManager.transition`, not `Player.status =`/`OrderManager` methods. They keep a **display-only** `Player.status` mirror write (never read back by `TimerView`) so `SettingsView` — unrewired until #62 — doesn't show stale status; tracked as tech debt in code comments for #62 to remove.
- `ActivePlayerRowView`/`BenchPlayerRowView`/`TemporarilyOutPlayerRowView`/`PlayerActionsSheetView` (and the section views between them and `TimerView`) now receive resolved `status`/`currentPlayDuration`/`totalPlayTime` as parameters instead of reading them off `Player` directly.
- Substitution (automatic + manual) stays on its existing `Player.status`/`OrderManager` path — out of scope here, full rewire is #61 — but also calls `GameManager.manualSubstitution` in parallel, so the `Game`/`Stint` state this ticket's display path depends on doesn't drift out of sync with a substitution performed through the old path. Tracked as tech debt in code comments for #61 to remove the now-redundant old-path writes.
- `docs/architecture/data-model.md` updated with this ticket's sequence diagram.

## Notable design decisions (see PR discussion / linked issue for full rationale)

- Ordering-within-a-bucket now derives entirely from `Game.activeOrder`/`benchOrder` rather than the legacy `OrderManager`, since acceptance criteria required these three actions to stop calling `OrderManager` at all — `OrderManager` remains only for Substitution's still-active legacy path.
- `docs/adr/0004-bench-active-order-as-dedicated-records.md` references `syncOrderManager(role:status:)` running "on every appear" as illustrative rationale; that specific call is now removed from `TimerView`'s render path (superseded by `resolveOrCreateGame`/`GameManager`-derived ordering for these three actions). The ADR's core decision (role-tagged `OrderManager` over subclassing) is unaffected and not amended here — flagging for awareness, not fixing as part of this PR's scope.

## Verification

- `swiftlint lint --strict`: 0 violations.
- Full unit test suite (`SubTimerTests`, 114 tests including 11 new): all pass.
- `SubTimerUITests/TimerViewUITests` (7 tests) and `SubTimerUITests/PlayerComponentsUITests` (5 non-performance tests): all pass, unmodified — confirming activate/temp-out/return-to-bench/substitution flows are visually and behaviorally unchanged.
- Build succeeds for iOS Simulator (macOS destination isn't valid for this project — `ActivityKit`/`Activity` unavailable on macOS, pre-existing and unrelated).

## Reviewed via two-axis code review (Standards + Spec)

Both axes ran before this PR was opened; findings were addressed:
- Fixed a real correctness bug where the `Game` bootstrap dropped every player's historical `totalPlayTime` (Standards + Spec review both caught this independently).
- Moved the bootstrap-seeding logic from `TimerView` into `GameManager` to preserve its documented "sole mutator of `Game`/`Stint`" invariant.
- Bundled the bootstrap's 5 loosely-related inputs into a `LegacyRotationSnapshot` struct (also fixed a `function_parameter_count` SwiftLint violation this surfaced).
- Corrected `docs/architecture/data-model.md` wording that inaccurately implied `GameManager.automaticSubstitution` is called from `TimerView` (it isn't — both substitution flows resolve their pair first, then call `manualSubstitution`).