### PR TITLE
Rewire Substitution and Live Activity feed onto GameManager

### DIFF
--- a/SubTimer/Views/TimerView.swift
+++ b/SubTimer/Views/TimerView.swift
@@ -97,13 +97,11 @@ struct TimerView: View {
     @Query(sort: \Player.sortOrder) var players: [Player]
     @Query private var configurations: [AppConfiguration]
     @Query(sort: \Session.startDate, order: .reverse) var sessions: [Session]
-    @Query private var orderManagers: [OrderManager]
     @Query private var teams: [Team]
     @Query private var games: [Game]
 
     @State var timerViewModel: TimerViewModel?
     @State private var activeSheet: TimerSheet?
-    @State private var cachedManagers: [PlayerOrderRole: OrderManager] = [:]
     @State private var currentGame: Game?
     @State private var showPinnedButton = false
     @State private var overtimeUpdateWork: DispatchWorkItem?
@@ -138,27 +136,6 @@ struct TimerView: View {
     }
 
     var gameManager: GameManager { GameManager(context: modelContext) }
-
-    func orderManager(for role: PlayerOrderRole) -> OrderManager {
-        if let cached = cachedManagers[role] {
-            return cached
-        }
-
-        if let manager = orderManagers.first(where: { $0.role == role }) {
-            cachedManagers[role] = manager
-            return manager
-        } else {
-            let newManager = OrderManager(role: role)
-            modelContext.insert(newManager)
-            try? modelContext.save()
-            cachedManagers[role] = newManager
-            return newManager
-        }
-    }
-
-    var benchManager: OrderManager { orderManager(for: .bench) }
-
-    var activeManager: OrderManager { orderManager(for: .active) }
 
     var activePlayers: [Player] {
         guard let game = currentGame else { return [] }
@@ -221,9 +198,6 @@ struct TimerView: View {
             }
             .navigationTitle("Super Sub")
             .onAppear {
-                // Initialize cached managers first
-                _ = benchManager
-                _ = activeManager
                 initializeViewModel(allPlayers: players)
                 resolveOrCreateGame()
             }
@@ -484,12 +458,23 @@ extension TimerView {
 
     /// Resolves `currentGame` to the `Team`'s open `Game` (no `endDate` yet),
     /// or creates one. A fresh `Game` only exists here (no open `Game` found)
-    /// in two cases: a real user's very first launch after this ticket ships
+    /// in two cases: a real user's very first launch after #60 shipped
     /// (migration only produces closed, historical `Game`s from old
     /// `Session`s - never an open one), or the `--uitesting` fixture launch
     /// (no `Team`/`Game` at all). `GameManager.seedFromLegacyStatus` bridges
     /// both by carrying the current `Player.status`-driven state into the
-    /// new `Game` exactly once, at creation.
+    /// new `Game` exactly once, at creation - this one-time read of
+    /// `Player.status` is the sole exception to #61's removal of
+    /// `Player.status`/`currentPlayDuration`/`totalPlayTime`/`OrderManager`
+    /// from the rest of this view: it's the historical migration bridge, not
+    /// an ongoing mirror, and both the `--uitesting` fixture
+    /// (`SubTimerApp.setupTestData`) and `TimerViewUITests` depend on it
+    /// seeding bucket membership correctly. `OrderManager`'s prior custom
+    /// order is no longer preserved here now that #61 removes `OrderManager`
+    /// from this view entirely - a one-time bootstrap falls back to roster
+    /// (`Player.sortOrder`) order instead, same as `seedFromLegacyStatus`
+    /// already does for any player missing from `existingActiveOrder`/
+    /// `existingBenchOrder`.
     func resolveOrCreateGame() {
         guard currentGame == nil else { return }
         let resolvedTeam = team
@@ -509,8 +494,8 @@ extension TimerView {
             activePlayers: players.filter { $0.status == .active },
             benchedPlayers: players.filter { $0.status == .benched },
             temporarilyOutPlayers: players.filter { $0.status == .temporarilyOut },
-            existingActiveOrder: activeManager.playerOrder,
-            existingBenchOrder: benchManager.playerOrder
+            existingActiveOrder: [],
+            existingBenchOrder: []
         )
         gameManager.seedFromLegacyStatus(snapshot, in: newGame)
         currentGame = newGame
@@ -547,7 +532,6 @@ extension TimerView {
         guard let game = currentGame, activePlayers.isEmpty else { return }
         let allFilteredPlayers = activePlayers + benchedPlayers + temporarilyOutPlayers
         let playersToActivate = min(configuration.activePlayersCount, allFilteredPlayers.count)
-        let now = Date()
         for index in 0..<playersToActivate where index < allFilteredPlayers.count {
             let player = allFilteredPlayers[index]
             do {
@@ -560,18 +544,11 @@ extension TimerView {
                     "GameManager.transition failed for a player already resolved from the context: \(error)"
                 )
             }
-            player.status = .active
-            player.activatedAtDate = now
-            player.currentPlayDuration = 0
         }
     }
 
     private func updatePlayerTimes() {
         let now = Date()
-
-        for player in activePlayers {
-            player.currentPlayDuration = now.timeIntervalSince(player.activatedAtDate)
-        }
 
         if let activeSession = sessions.first(where: { $0.isActive }) {
             activeSession.duration = now.timeIntervalSince(activeSession.startDate)
@@ -603,42 +580,25 @@ extension TimerView {
     }
 
     private func performSubstitution(subOut: Player, subIn: Player) {
-        let now = Date()
         let wasRunning = timerViewModel?.isRunning ?? false
 
         if wasRunning {
             timerViewModel?.pauseTimer()
         }
 
-        let timePlayedThisSegment = now.timeIntervalSince(subOut.activatedAtDate)
-        subOut.totalPlayTime += timePlayedThisSegment
-        subOut.status = .benched
-        subOut.currentPlayDuration = 0
-
-        subIn.status = .active
-        subIn.activatedAtDate = now
-        subIn.currentPlayDuration = 0
-
-        benchManager.removePlayer(subIn.id)
-        benchManager.addPlayer(subOut.id)
-
-        activeManager.removePlayer(subOut.id)
-        activeManager.addPlayer(subIn.id)
-
-        // Substitution stays on the Player.status/OrderManager path above
-        // (rewiring it fully onto GameManager is #61's job) but also mirrors
-        // the swap into Game/Stint here, so the Game-derived duration values
-        // (see PlayerActionsSheetView/row views) stay correct in the interim.
+        // GameManager is the sole substitution path (issue #61): it closes
+        // subOut's open Stint (adding its duration to their total), opens a
+        // fresh zero-duration Stint for subIn, and moves both players
+        // between Game.activeOrder/benchOrder in one call. subOut/subIn are
+        // always resolved from activePlayers/benchedPlayers (themselves
+        // derived from gameManager.status), so a thrown error here would
+        // mean a real programming bug, not a recoverable runtime state.
         if let game = currentGame {
             do {
                 try gameManager.manualSubstitution(outgoing: subOut.id, incoming: subIn.id, game: game)
             } catch {
-                // Unlike the transition() sites above, the legacy path and this mirror
-                // aren't the same call, so a throw here is a real drift signal between
-                // Player.status/OrderManager and Game/Stint, not just a defensive check.
                 assertionFailure(
-                    "GameManager.manualSubstitution mirror failed, Game/Stint state has drifted from legacy path: "
-                        + "\(error)"
+                    "GameManager.manualSubstitution failed for players already resolved from the context: \(error)"
                 )
             }
         }
@@ -660,12 +620,12 @@ extension TimerView {
         }
     }  // MARK: - Player Status
 
-    // Activate/mark-temporarily-out/return-to-bench read/write Game via
-    // GameManager exclusively now (issue #60) - the Player.status write in
-    // each is a display-only mirror for SettingsView, which still reads
-    // Player.status directly until #62 rewires it onto TeamManager/Game;
-    // TimerView itself never reads these three fields back. Tracked as
-    // tech debt to remove in #62 alongside Player.status's deletion.
+    // Activate/mark-temporarily-out/return-to-bench, and substitution above,
+    // read/write Game exclusively via GameManager now (issues #60/#61) - no
+    // Player.status/currentPlayDuration/totalPlayTime mirror remains here.
+    // SettingsView, unrewired until a later ticket, still reads Player.status/
+    // currentPlayDuration/totalPlayTime directly and will show stale values
+    // for a player changed here until that ticket lands.
 
     func activatePlayer(_ player: Player) {
         guard let game = currentGame else { return }
@@ -674,31 +634,18 @@ extension TimerView {
         } catch {
             assertionFailure("GameManager.transition failed for a player already resolved from the context: \(error)")
         }
-
-        player.status = .active
-        player.activatedAtDate = Date()
-        player.currentPlayDuration = 0
         updateLiveActivity()
     }
 
     func markPlayerTemporarilyOut(_ player: Player) {
         guard let game = currentGame else { return }
-        let wasActive = gameManager.status(playerId: player.id, in: game) == .active
         try? gameManager.transition(playerId: player.id, to: .temporarilyOut, in: game)
-
-        if wasActive {
-            let timePlayedThisSegment = Date().timeIntervalSince(player.activatedAtDate)
-            player.totalPlayTime += timePlayedThisSegment
-        }
-        player.status = .temporarilyOut
         updateLiveActivity()
     }
 
     func returnPlayerToBench(_ player: Player) {
         guard let game = currentGame else { return }
         try? gameManager.transition(playerId: player.id, to: .benched, in: game)
-
-        player.status = .benched
         updateLiveActivity()
     }
 
@@ -726,6 +673,7 @@ extension TimerView {
     // MARK: - Live Activity Management
 
     private func startLiveActivity() {
+        guard let game = currentGame else { return }
         if #available(iOS 16.2, *) {
             let sessionName: String
             if let activeSession = sessions.first(where: { $0.isActive }) {
@@ -741,7 +689,7 @@ extension TimerView {
                 isRunning: timerViewModel?.isRunning ?? false,
                 timerStartDate: timerViewModel?.timerStartDate ?? Date(),
                 accumulatedTime: timerViewModel?.accumulatedTime ?? 0,
-                preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
+                preferredPlayTimeSeconds: game.preferredPlayTimeSeconds,
                 activePlayersCount: activePlayers.count,
                 benchedPlayersCount: benchedPlayers.count,
                 subOutPlayerName: activePlayers.first?.name,
@@ -752,12 +700,13 @@ extension TimerView {
     }
 
     private func updateLiveActivity() {
+        guard let game = currentGame else { return }
         if #available(iOS 16.2, *) {
             LiveActivityManager.shared.updateActivity(
                 isRunning: timerViewModel?.isRunning ?? false,
                 timerStartDate: timerViewModel?.timerStartDate ?? Date(),
                 accumulatedTime: timerViewModel?.accumulatedTime ?? 0,
-                preferredPlayTimeSeconds: configuration.preferredPlayTimeSeconds,
+                preferredPlayTimeSeconds: game.preferredPlayTimeSeconds,
                 activePlayersCount: activePlayers.count,
                 benchedPlayersCount: benchedPlayers.count,
                 subOutPlayerName: activePlayers.first?.name,
@@ -776,7 +725,8 @@ extension TimerView {
     private func scheduleOvertimeUpdate() {
         cancelOvertimeUpdate()
 
-        let preferredSeconds = configuration.preferredPlayTimeSeconds
+        guard let game = currentGame else { return }
+        let preferredSeconds = game.preferredPlayTimeSeconds
         guard preferredSeconds > 0 else { return }
 
         let accumulated = timerViewModel?.accumulatedTime ?? 0
@@ -797,8 +747,7 @@ extension TimerView {
 }
 
 /// Registers the full app schema (see `SchemaV2.models`) so `TimerView`'s
-/// `@Query`s for `OrderManager`/`Team`/`Game`/`Stint` don't crash at preview
-/// render time.
+/// `@Query`s for `Team`/`Game`/`Stint` don't crash at preview render time.
 private let previewSchemaModels: [any PersistentModel.Type] = [
     Player.self, AppConfiguration.self, Session.self, OrderManager.self,
     Team.self, RosterMembership.self, Game.self, Stint.self

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -7,10 +7,11 @@ The persisted model is mid-transition between two shapes:
   transition is complete; `Session`, `OrderManager`, and `AppConfiguration`
   are expected to be superseded by the dormant types below.
 - **Partially in use:** `Team`, `RosterMembership`, `Game`, `Stint` —
-  `TimerView`'s activate/mark-temporarily-out/return-to-bench actions and
-  Active/Bench/Temporarily-Out section rendering read/write these via
-  `GameManager` (#60); `RosterMembership` and Substitution's own bucket/Stint
-  bookkeeping remain unread/unwritten by app UI until later tickets.
+  `TimerView`'s activate/mark-temporarily-out/return-to-bench/substitution
+  actions, its Active/Bench/Temporarily-Out section rendering, and its Live
+  Activity feed all read/write these via `GameManager` (#60/#61);
+  `RosterMembership` remains unread/unwritten by app UI until a later
+  ticket rewires `SettingsView` onto `TeamManager`/`Team`.
 
 ```mermaid
 classDiagram
@@ -201,22 +202,10 @@ changing membership — `.temporarilyOut` is a no-op, since it's an unordered
 `Game` is only created when no open one exists for the app's `Team` — for a
 real upgrading user, migration (#59) only produces closed, historical
 `Game`s, so a fresh `Game` is bootstrapped once from each player's current
-`Player.status`/`activatedAtDate`/`OrderManager` order, carrying an
-in-progress rotation into the new model without resetting it.
-
-Substitution (still out of scope for a full rewire until #61) keeps its
-existing `Player.status`/`OrderManager` writes, but also calls
-`GameManager.manualSubstitution` in parallel (for both the automatic and
-manual flows - `TimerView` already resolves the specific outgoing/incoming
-pair before either reaches this call, so there's no separate need for
-`GameManager.automaticSubstitution`'s own pairing logic here), so the
-`Game`/`Stint` state this ticket's display path depends on doesn't drift out
-of sync with a substitution performed through the old path. `activatePlayer`/
-`markPlayerTemporarilyOut`/`returnPlayerToBench` similarly keep a
-display-only `Player.status` mirror write (never read back by `TimerView`)
-purely so `SettingsView` — unrewired until #62 — doesn't show stale status;
-this mirror is tracked as tech debt to remove alongside `Player.status`'s
-deletion in #62.
+`Player.status`/`activatedAtDate`, carrying an in-progress rotation into the
+new model without resetting it (#61 dropped this bootstrap's use of
+`OrderManager` to preserve a prior custom order, in step with removing
+`OrderManager` from the rest of the view — see below).
 
 ```mermaid
 sequenceDiagram
@@ -239,8 +228,77 @@ sequenceDiagram
     Section-->>Coach: renders - identical to today, no direct player.status/currentPlayDuration reads
 ```
 
-Substitution stays on its existing path for its own display logic here — see
-#61 for the follow-on ticket that rewires Substitution and the Live Activity
-feed fully onto `GameManager`, at which point `Player.status`/
-`currentPlayDuration`/`totalPlayTime`/`OrderManager` will have no remaining
-references anywhere in `TimerView`.
+As of #60, Substitution still kept its own `Player.status`/`OrderManager`
+writes in parallel with a `GameManager.manualSubstitution` mirror call — see
+below for #61, the follow-on ticket that removed that legacy path.
+
+## Substitution and Live Activity rewired onto GameManager (#61)
+
+Automatic and Manual Substitution now run through `GameManager` exclusively:
+both variants resolve an outgoing/incoming pair, then make a single
+`GameManager.manualSubstitution(outgoing:incoming:game:)` call — there's no
+separate need for `GameManager.automaticSubstitution`'s own pairing logic in
+`TimerView`, since it already resolves the specific pair itself before
+either flow reaches this call. `activatePlayer`/`markPlayerTemporarilyOut`/
+`returnPlayerToBench`/`performSubstitution`/`autoActivateInitialPlayersIfNeeded`
+no longer write `Player.status`/`currentPlayDuration`/`totalPlayTime`, and
+`OrderManager` is gone from `TimerView` entirely — every rotation read and
+write in the view now goes through `GameManager` against `Game`.
+
+`TimerView`'s Live Activity start/update call sites
+(`startLiveActivity`/`updateLiveActivity`/`scheduleOvertimeUpdate`) now read
+`preferredPlayTimeSeconds` from the open `Game` instead of
+`AppConfiguration`; the player counts/names they pass
+(`activePlayers.count`/`benchedPlayers.count`/`.first?.name`) were already
+`Game`-derived as of #60's `activePlayers`/`benchedPlayers` computed
+properties, so no further change was needed there.
+
+One reference to `Player.status` remains in `TimerView`, in
+`resolveOrCreateGame()`'s one-time legacy-bootstrap read (see #60 above) —
+it's the historical migration bridge, not an ongoing mirror, and both the
+`--uitesting` fixture (`SubTimerApp.setupTestData`) and `TimerViewUITests`
+depend on it seeding bucket membership correctly on a brand-new `Game`.
+
+Because `SettingsView` is unrewired until a later ticket and still reads/
+writes `Player.status`/`currentPlayDuration`/`totalPlayTime` directly, a
+player changed through `TimerView` now shows stale values on the Settings
+screen until that ticket lands — an accepted, temporary consequence of
+migrating screen-by-screen. The same applies to `preferredPlayTimeSeconds`:
+`Game`'s copy is a snapshot taken at creation time, so a mid-session change
+in `SettingsView` (still `AppConfiguration`-backed) won't reach the Live
+Activity until `SettingsView` is rewired onto `Team`.
+
+```mermaid
+sequenceDiagram
+    participant Coach
+    participant TimerView
+    participant GameManager
+    participant Stint
+    participant Game
+    participant LiveActivityManager
+    participant ActivityKit as ActivityKit / Dynamic Island
+
+    alt Automatic Substitution
+        Coach->>TimerView: tap Substitute
+        TimerView->>GameManager: resolve longest-serving Active + Next Up Bench player
+    else Manual Substitution
+        Coach->>TimerView: pick outgoing + incoming players
+        TimerView->>GameManager: manualSubstitution(outgoing, incoming, game)
+    end
+
+    GameManager->>GameManager: transition(outgoing, to: .benched, in: game)
+    GameManager->>Stint: close outgoing's Stint, add duration to total
+    GameManager->>GameManager: transition(incoming, to: .active, in: game)
+    GameManager->>Stint: open new Stint for incoming, starting at zero
+    GameManager->>Game: substitutionCount += 1
+    GameManager-->>TimerView: updated Game/Stint state
+
+    TimerView->>LiveActivityManager: update(team: Team, game: Game)
+    LiveActivityManager->>ActivityKit: push ContentState (shape unchanged)
+    ActivityKit-->>Coach: lock screen / Dynamic Island reflects the swap
+```
+
+After this ticket, `TimerView` has no remaining ongoing references to
+`Player.status`/`currentPlayDuration`/`totalPlayTime`/`OrderManager` —
+every rotation read and write in that view goes through `GameManager`, and
+every Live Activity read goes through `Game`.


### PR DESCRIPTION
Closes #61.

## Summary

- `performSubstitution` now makes a single `GameManager.manualSubstitution` call as the sole substitution path (for both the automatic and manual flows) — no more parallel `Player.status`/`OrderManager` writes.
- `activatePlayer`/`markPlayerTemporarilyOut`/`returnPlayerToBench`/`autoActivateInitialPlayersIfNeeded`/`updatePlayerTimes` drop their `Player.status`/`currentPlayDuration`/`totalPlayTime` mirror writes.
- `OrderManager` is gone from `TimerView` entirely (the `@Query`, cached-manager plumbing, `benchManager`/`activeManager`). `resolveOrCreateGame()`'s one-time legacy bootstrap no longer preserves `OrderManager`'s prior custom order, falling back to roster order the same way `seedFromLegacyStatus` already does for any player missing from `existingActiveOrder`/`existingBenchOrder`.
- `startLiveActivity`/`updateLiveActivity`/`scheduleOvertimeUpdate` now read `preferredPlayTimeSeconds` from the open `Game` instead of `AppConfiguration`; the player counts/names they pass were already `Game`-derived as of #60, so no further change was needed there.
- `docs/architecture/data-model.md`: adds the #61 architecture section (with the substitution/Live Activity sequence diagram) and corrects the #60 section's now-stale description of Substitution's legacy dual-write and the `OrderManager`-preserving bootstrap.

## Known, disclosed scoping decision

One `Player.status` read survives in `resolveOrCreateGame()`'s one-time legacy-bootstrap seed — it's the historical migration bridge (not an ongoing mirror), and both the `--uitesting` fixture (`SubTimerApp.setupTestData`) and `TimerViewUITests` depend on it to correctly seed bucket membership on a brand-new `Game`. Removing it breaks that seeding path. This is documented in both the code comment and `data-model.md`.

## Verification

- `swiftlint lint --strict`: 0 violations.
- `xcodebuild build`: succeeds.
- `SubTimerTests`: 128/128 pass (run with `-parallel-testing-enabled NO` — the shipped CI config already isolates a pre-existing `DataMigrationTests`/`ModelContainer` parallel-run flakiness that's unrelated to this change and reproduces identically on `main`).
- `SubTimerUITests/TimerViewUITests`: 7/7 pass.
- `SubTimerUITests/SettingsViewUITests`: 6/6 pass.
- `SubTimerUITests/PlayerComponentsUITests` (non-performance): 5/5 pass.